### PR TITLE
Implement broadcast ordering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 sudo: false
+dist: trusty
+addons:
+    apt:
+        packages:
+            - oracle-java8-installer
+
 language: java
 jdk:
     - oraclejdk8

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,4 +3,6 @@ Vagrant.configure(2) do |config|
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder ".", "/home/vagrant/workspace"
     config.vm.provision "docker"
+    config.vm.provision "shell", name: "Install Travis CI Gem",
+        inline: "{ apt-get -y install ruby-dev && gem install travis ; } &> /dev/null"
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure(2) do |config|
-    config.vm.box = "ubuntu/vivid64"
+    config.vm.box = "ubuntu/trusty64"
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder ".", "/home/vagrant/workspace"
     (1..4).each do |i|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,28 +2,5 @@ Vagrant.configure(2) do |config|
     config.vm.box = "ubuntu/trusty64"
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder ".", "/home/vagrant/workspace"
-    (1..4).each do |i|
-        config.vm.define "m#{i}" do |config|
-            config.vm.hostname = "m#{i}"
-            config.vm.provision "shell", privileged: false, inline: %(
-                if [[ ! -d .files ]]
-                then
-                    mkdir .files
-                    curl -sL https://git.io/vuHfs | tar -xz -C .files --strip-components=1
-                    VAGRANT=true .files/install 2>&1 &> /dev/null
-                fi
-                sudo add-apt-repository -y ppa:cwchien/gradle
-                sudo apt-get -qqy update
-                sudo apt-get -qqy dist-upgrade
-                sudo apt-get -qqy install \
-                    gradle-2.10 \
-                    htop \
-                    openjdk-8-jdk \
-                    # END PACKAGE LIST
-            )
-            config.vm.provider "virtualbox" do |virtualbox|
-                virtualbox.linked_clone = true
-            end
-        end
-    end
+    config.vm.provision "docker"
 end

--- a/src/main/java/rx/broadcast/BasicOrder.java
+++ b/src/main/java/rx/broadcast/BasicOrder.java
@@ -1,0 +1,10 @@
+package rx.broadcast;
+
+import java.util.function.Consumer;
+
+public final class BasicOrder<T> implements BroadcastOrder<T> {
+    @Override
+    public void receive(final int sender, final Consumer<T> consumer, final Timestamped<T> message) {
+        consumer.accept(message.value);
+    }
+}

--- a/src/main/java/rx/broadcast/BroadcastOrder.java
+++ b/src/main/java/rx/broadcast/BroadcastOrder.java
@@ -1,0 +1,8 @@
+package rx.broadcast;
+
+import java.util.function.Consumer;
+
+@FunctionalInterface
+public interface BroadcastOrder<T> {
+    void receive(final int sender, final Consumer<T> consumer, final Timestamped<T> message);
+}

--- a/src/main/java/rx/broadcast/SingleSourceFifoOrder.java
+++ b/src/main/java/rx/broadcast/SingleSourceFifoOrder.java
@@ -1,0 +1,58 @@
+package rx.broadcast;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.function.Consumer;
+
+public final class SingleSourceFifoOrder<T> implements BroadcastOrder<T> {
+    public static final boolean DROP_LATE = true;
+
+    private final Map<Integer, SortedSet<Timestamped<T>>> pendingQueues;
+
+    private long expectedTimestamp;
+
+    private final boolean dropLateMessages;
+
+    public SingleSourceFifoOrder() {
+        this(false);
+    }
+
+    public SingleSourceFifoOrder(final boolean dropLateMessages) {
+        this.pendingQueues = new HashMap<>();
+        this.dropLateMessages = dropLateMessages;
+    }
+
+    @Override
+    public void receive(final int sender, final Consumer<T> consumer, final Timestamped<T> value) {
+        if (dropLateMessages) {
+            if (Long.compareUnsigned(value.timestamp, expectedTimestamp) >= 0) {
+                consumer.accept(value.value);
+                expectedTimestamp = value.timestamp + 1;
+            }
+
+            return;
+        }
+
+        final SortedSet<Timestamped<T>> queue = pendingQueues.computeIfAbsent(sender, k -> new TreeSet<>());
+
+        if (value.timestamp == expectedTimestamp) {
+            consumer.accept(value.value);
+            expectedTimestamp = value.timestamp + 1;
+        } else {
+            queue.add(value);
+        }
+
+        final Iterator<Timestamped<T>> iterator = queue.iterator();
+        while (iterator.hasNext()) {
+            final Timestamped<T> tv = iterator.next();
+            if (tv.timestamp <= expectedTimestamp) {
+                consumer.accept(tv.value);
+                expectedTimestamp = tv.timestamp + 1;
+                iterator.remove();
+            }
+        }
+    }
+}

--- a/src/main/java/rx/broadcast/Timestamped.java
+++ b/src/main/java/rx/broadcast/Timestamped.java
@@ -1,0 +1,22 @@
+package rx.broadcast;
+
+final class Timestamped<T> implements Comparable<Timestamped<T>> {
+    public long timestamp;
+
+    public T value;
+
+    @SuppressWarnings("unused")
+    public Timestamped() {
+
+    }
+
+    public Timestamped(final long timestamp, final T value) {
+        this.timestamp = timestamp;
+        this.value = value;
+    }
+
+    @Override
+    public int compareTo(final Timestamped<T> other) {
+        return Long.compareUnsigned(timestamp, other.timestamp);
+    }
+}

--- a/src/main/java/rx/broadcast/time/Clock.java
+++ b/src/main/java/rx/broadcast/time/Clock.java
@@ -1,0 +1,7 @@
+package rx.broadcast.time;
+
+import java.util.function.Function;
+
+public interface Clock {
+    <T> T tick(final Function<Long, T> ticker);
+}

--- a/src/main/java/rx/broadcast/time/LamportClock.java
+++ b/src/main/java/rx/broadcast/time/LamportClock.java
@@ -1,0 +1,30 @@
+package rx.broadcast.time;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+
+public final class LamportClock implements Clock {
+    private final Lock lock;
+
+    private long time = -1L;
+
+    public LamportClock() {
+        this(new ReentrantLock());
+    }
+
+    public LamportClock(final Lock lock) {
+        this.lock = lock;
+    }
+
+    @Override
+    public <T> T tick(final Function<Long, T> ticker) {
+        lock.lock();
+        try {
+            time = time + 1;
+            return ticker.apply(time);
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/src/test/java/rx/broadcast/SingleSourceFifoOrderTest.java
+++ b/src/test/java/rx/broadcast/SingleSourceFifoOrderTest.java
@@ -1,0 +1,73 @@
+package rx.broadcast;
+
+import org.junit.Test;
+import rx.observers.TestSubscriber;
+
+import java.util.Arrays;
+
+public class SingleSourceFifoOrderTest {
+    @SuppressWarnings({"Checkstyle:MagicNumber"})
+    @Test
+    public final void receiveMessagesInOrder() {
+        final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
+        final Timestamped<TestValue> value0 = new Timestamped<>(0, new TestValue(41));
+        final Timestamped<TestValue> value1 = new Timestamped<>(1, new TestValue(42));
+        final Timestamped<TestValue> value2 = new Timestamped<>(2, new TestValue(43));
+        final SingleSourceFifoOrder<TestValue> ssf = new SingleSourceFifoOrder<>();
+
+        ssf.receive(0, consumer::onNext, value0);
+        ssf.receive(0, consumer::onNext, value1);
+        ssf.receive(0, consumer::onNext, value2);
+
+        consumer.assertReceivedOnNext(Arrays.asList(value0.value, value1.value, value2.value));
+    }
+
+    @Test
+    public final void receiveMessagesOutOfOrder() {
+        final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
+        final Timestamped<TestValue> value0 = new Timestamped<>(0, new TestValue(41));
+        final Timestamped<TestValue> value1 = new Timestamped<>(1, new TestValue(42));
+        final Timestamped<TestValue> value2 = new Timestamped<>(2, new TestValue(43));
+        final SingleSourceFifoOrder<TestValue> ssf = new SingleSourceFifoOrder<>();
+
+        ssf.receive(0, consumer::onNext, value1);
+        ssf.receive(0, consumer::onNext, value0);
+        ssf.receive(0, consumer::onNext, value2);
+
+        consumer.assertReceivedOnNext(Arrays.asList(value0.value, value1.value, value2.value));
+    }
+
+    @Test
+    public final void receiveMessagesInReverseOrder() {
+        final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
+        final Timestamped<TestValue> value0 = new Timestamped<>(0, new TestValue(41));
+        final Timestamped<TestValue> value1 = new Timestamped<>(1, new TestValue(42));
+        final Timestamped<TestValue> value2 = new Timestamped<>(2, new TestValue(43));
+        final Timestamped<TestValue> value3 = new Timestamped<>(3, new TestValue(44));
+        final SingleSourceFifoOrder<TestValue> ssf = new SingleSourceFifoOrder<>();
+
+        ssf.receive(0, consumer::onNext, value3);
+        ssf.receive(0, consumer::onNext, value2);
+        ssf.receive(0, consumer::onNext, value1);
+        ssf.receive(0, consumer::onNext, value0);
+
+        consumer.assertReceivedOnNext(Arrays.asList(value0.value, value1.value, value2.value, value3.value));
+    }
+
+    @Test
+    public final void receiveMessagesWithDropLateFlagDoesDropLateMessages() {
+        final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
+        final Timestamped<TestValue> value0 = new Timestamped<>(0, new TestValue(41));
+        final Timestamped<TestValue> value1 = new Timestamped<>(1, new TestValue(42));
+        final Timestamped<TestValue> value2 = new Timestamped<>(2, new TestValue(43));
+        final Timestamped<TestValue> value3 = new Timestamped<>(3, new TestValue(44));
+        final SingleSourceFifoOrder<TestValue> ssf = new SingleSourceFifoOrder<>(SingleSourceFifoOrder.DROP_LATE);
+
+        ssf.receive(0, consumer::onNext, value2);
+        ssf.receive(0, consumer::onNext, value0);
+        ssf.receive(0, consumer::onNext, value1);
+        ssf.receive(0, consumer::onNext, value3);
+
+        consumer.assertReceivedOnNext(Arrays.asList(value2.value, value3.value));
+    }
+}

--- a/src/test/java/rx/broadcast/UdpBroadcastTest.java
+++ b/src/test/java/rx/broadcast/UdpBroadcastTest.java
@@ -47,8 +47,10 @@ public class UdpBroadcastTest {
         final TestSubscriber<Object> subscriber = new TestSubscriber<>();
         final DatagramSocket s1 = datagramSocketSupplier.get();
         final DatagramSocket s2 = datagramSocketSupplier.get();
-        final Broadcast broadcast1 = new UdpBroadcast(s1, InetAddress.getLoopbackAddress(), s2.getLocalPort());
-        final Broadcast broadcast2 = new UdpBroadcast(s2, InetAddress.getLoopbackAddress(), s1.getLocalPort());
+        final Broadcast broadcast1 = new UdpBroadcast(
+            s1, InetAddress.getLoopbackAddress(), s2.getLocalPort(), new BasicOrder<>());
+        final Broadcast broadcast2 = new UdpBroadcast(
+            s2, InetAddress.getLoopbackAddress(), s1.getLocalPort(), new BasicOrder<>());
 
         broadcast2.valuesOfType(TestValue.class).first().subscribe(subscriber);
         broadcast1.send(new TestValue(42)).toBlocking().subscribe();
@@ -66,8 +68,10 @@ public class UdpBroadcastTest {
         final TestSubscriber<Object> subscriber = new TestSubscriber<>();
         final DatagramSocket s1 = datagramSocketSupplier.get();
         final DatagramSocket s2 = datagramSocketSupplier.get();
-        final Broadcast broadcast1 = new UdpBroadcast(s1, InetAddress.getLoopbackAddress(), s2.getLocalPort());
-        final Broadcast broadcast2 = new UdpBroadcast(s2, InetAddress.getLoopbackAddress(), s1.getLocalPort());
+        final Broadcast broadcast1 = new UdpBroadcast(
+            s1, InetAddress.getLoopbackAddress(), s2.getLocalPort(), new BasicOrder<>());
+        final Broadcast broadcast2 = new UdpBroadcast(
+            s2, InetAddress.getLoopbackAddress(), s1.getLocalPort(), new BasicOrder<>());
 
         broadcast2.valuesOfType(TestValue.class).take(4).subscribe(subscriber);
 
@@ -91,7 +95,8 @@ public class UdpBroadcastTest {
         final TestSubscriber<Void> subscriber = new TestSubscriber<>();
         final DatagramSocket s1 = datagramSocketSupplier.get();
         final DatagramSocket s2 = datagramSocketSupplier.get();
-        final Broadcast broadcast1 = new UdpBroadcast(s1, InetAddress.getLoopbackAddress(), s2.getLocalPort());
+        final Broadcast broadcast1 = new UdpBroadcast(
+            s1, InetAddress.getLoopbackAddress(), s2.getLocalPort(), new BasicOrder<>());
 
         s1.close();
         broadcast1.send(new TestValue(42)).toBlocking().subscribe(subscriber);


### PR DESCRIPTION
This PR implements broadcast message ordering on top of `UdpBroadcast`.

The constructor now accepts a `BroadcastOrder` and orders the received messages using that order.
