### PR TITLE
Prevent duplicate messages in UDP broadcast

### DIFF
--- a/src/main/java/rx/broadcast/SingleSourceFifoOrder.java
+++ b/src/main/java/rx/broadcast/SingleSourceFifoOrder.java
@@ -60,6 +60,10 @@ public final class SingleSourceFifoOrder<T> implements BroadcastOrder<Timestampe
         final Iterator<Timestamped<T>> iterator = queue.iterator();
         while (iterator.hasNext()) {
             final Timestamped<T> tv = iterator.next();
+            if (tv.timestamp < expectedTimestamp) {
+                iterator.remove();
+                continue;
+            }
             if (tv.timestamp > expectedTimestamp) {
                 break;
             }

--- a/src/test/java/rx/broadcast/CausalOrderTest.java
+++ b/src/test/java/rx/broadcast/CausalOrderTest.java
@@ -69,4 +69,22 @@ public class CausalOrderTest {
         consumer.assertReceivedOnNext(Arrays.asList(value0.value, value1.value));
         Assert.assertEquals(0, causalOrder.queueSize());
     }
+
+    /**
+     * See {@see CausalOrderTest#receiveMessagesInCausalOrder()} for drawing.
+     */
+    @Test
+    public final void receiveDuplicateMessagesInCausalOrder() {
+        final VectorTimestamped<TestValue> value0 = timestampedValue(42, new long[]{2}, new long[]{0});
+        final VectorTimestamped<TestValue> value1 = timestampedValue(43, new long[]{1, 2}, new long[]{0, 0});
+        final CausalOrder<TestValue> causalOrder = new CausalOrder<>();
+        final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
+
+        causalOrder.receive(1, consumer::onNext, value1);
+        causalOrder.receive(1, consumer::onNext, value1);
+        causalOrder.receive(2, consumer::onNext, value0);
+        causalOrder.receive(2, consumer::onNext, value0);
+
+        consumer.assertReceivedOnNext(Arrays.asList(value0.value, value1.value));
+    }
 }

--- a/src/test/java/rx/broadcast/SingleSourceFifoOrderTest.java
+++ b/src/test/java/rx/broadcast/SingleSourceFifoOrderTest.java
@@ -70,4 +70,38 @@ public class SingleSourceFifoOrderTest {
 
         consumer.assertReceivedOnNext(Arrays.asList(value2.value, value3.value));
     }
+
+    @Test
+    public final void receiveDuplicateMessagesInOrder() {
+        final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
+        final Timestamped<TestValue> value0 = new Timestamped<>(0, new TestValue(41));
+        final Timestamped<TestValue> value1 = new Timestamped<>(0, new TestValue(41));
+        final Timestamped<TestValue> value2 = new Timestamped<>(1, new TestValue(42));
+        final Timestamped<TestValue> value3 = new Timestamped<>(1, new TestValue(42));
+        final SingleSourceFifoOrder<TestValue> ssf = new SingleSourceFifoOrder<>();
+
+        ssf.receive(0, consumer::onNext, value0);
+        ssf.receive(0, consumer::onNext, value1);
+        ssf.receive(0, consumer::onNext, value2);
+        ssf.receive(0, consumer::onNext, value3);
+
+        consumer.assertReceivedOnNext(Arrays.asList(value0.value, value2.value));
+    }
+
+    @Test
+    public final void receiveDuplicateMessagesInReverseOrder() {
+        final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
+        final Timestamped<TestValue> value0 = new Timestamped<>(0, new TestValue(41));
+        final Timestamped<TestValue> value1 = new Timestamped<>(0, new TestValue(41));
+        final Timestamped<TestValue> value2 = new Timestamped<>(1, new TestValue(42));
+        final Timestamped<TestValue> value3 = new Timestamped<>(1, new TestValue(42));
+        final SingleSourceFifoOrder<TestValue> ssf = new SingleSourceFifoOrder<>();
+
+        ssf.receive(0, consumer::onNext, value3);
+        ssf.receive(0, consumer::onNext, value2);
+        ssf.receive(0, consumer::onNext, value1);
+        ssf.receive(0, consumer::onNext, value0);
+
+        consumer.assertReceivedOnNext(Arrays.asList(value0.value, value2.value));
+    }
 }


### PR DESCRIPTION
Closes #12

As UDP provides no duplicate protection, this PR adds tests for—and fixes—duplicate messages when using the SSF or causal orders.
