### PR TITLE
Update Vagrant provisioning steps

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,10 @@ Vagrant.configure(2) do |config|
     config.vm.box = "ubuntu/trusty64"
     config.vm.synced_folder ".", "/vagrant", disabled: true
     config.vm.synced_folder ".", "/home/vagrant/workspace"
-    config.vm.provision "docker"
+    config.vm.provision "shell", name: "Install Docker",
+        inline: "{ curl -fsSL https://get.docker.com/ | sh ; } &> /dev/null"
+    config.vm.provision "shell", name: "Install Docker",
+        inline: "{ sudo usermod -aG docker vagrant ; } &> /dev/null"
     config.vm.provision "shell", name: "Install Travis CI Gem",
         inline: "{ apt-get -y install ruby-dev && gem install travis ; } &> /dev/null"
 end


### PR DESCRIPTION
This PR updates the Vagrant provisioning to not use the built-in Docker installer (because it's slow).
