### PR TITLE
Remove default Bintray properties

### DIFF
--- a/gradle/deploy.gradle
+++ b/gradle/deploy.gradle
@@ -46,8 +46,8 @@ publishing {
 }
 
 bintray {
-    user = System.getenv('BINTRAY_USER') ?: bintrayUser
-    key = System.getenv('BINTRAY_API_KEY') ?: bintrayApiKey
+    user = System.getenv('BINTRAY_USER') ?: null
+    key = System.getenv('BINTRAY_API_KEY') ?: null
 
     publications = ['rxbroadcast']
     publish = true


### PR DESCRIPTION
This PR `null`s-out the defaults for the Bintray deployment config, requiring the use of envars.
