### PR TITLE
Prepare for v1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ script:
     - gradle build
     - gradle testJar
     - docker build -t rxb .
-    - scripts/test rx.broadcast.integration.SingleSourceFifoOrderUdpBroadcastTest 'sudo tc qdisc add dev $DOCKER_IFACE root netem delay 100ms 75ms'
     - scripts/test rx.broadcast.integration.BasicOrderUdpBroadcastTest
 deploy:
     provider: script

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,35 @@
-How to contribute to RxBroadcast
-================================
+Contributing to RxBroadcast
+===========================
 
 By contributing to this project, you agree to license your contribution(s) under the terms outlined in the [`LICENSE`](LICENSE.md) file in the repository.
+
+GitHub
+------
+
+All RxBroadcast devlopment happens through GitHub. If you're new to GitHub, start with some of [their awesome guides](https://guides.github.com):
+
+- [Contributing to Open Source on GitHub](https://guides.github.com/activities/contributing-to-open-source/)
+- [Forking Projects](https://guides.github.com/activities/forking/)
+- [Understanding the GitHub Flow](https://guides.github.com/introduction/flow/)
+
+The build system
+----------------
+
+RxBroadcast uses Gradle as its build sysem. To build the project from the command line:
+
+```bash
+$ gradle build
+```
+
+To see a full list of Gradle tasks:
+
+```bash
+$ gradle tasks
+```
+
+Feature requests and bug reports
+--------------------------------
+
+Note that RxBroadcast is a library with an intentionally small feature set and API—it serves to describe a distributed event system. It is possible that you may want to wrap `Broadcast` objects or generally use them as building blocks.
+
+To request a change to the way that RxBroadcast works, or report an issue with the library, [open an issue](https://github.com/RxBroadcast/RxBroadcast/issues). Whether or not something is a bug can be tricky to tell, please feel free to always open an issue even if you're unsure.

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,10 @@ sourceSets {
     }
 }
 
+javadoc {
+    options.optionFiles << file('config/javadoc.opts')
+}
+
 test {
     exclude 'rx/broadcast/integration/**'
     testLogging {

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,22 @@ checkstyle {
     toolVersion = '6.15'
 }
 
+sourceSets {
+    main {
+        java {
+            exclude 'rx/broadcast/CausalOrder**'
+            exclude 'rx/broadcast/SingleSourceFifoOrder**'
+        }
+    }
+    test {
+        java {
+            exclude 'rx/broadcast/CausalOrder**'
+            exclude 'rx/broadcast/SingleSourceFifoOrder**'
+            exclude 'rx/broadcast/integration/SingleSourceFifoOrder**'
+        }
+    }
+}
+
 test {
     exclude 'rx/broadcast/integration/**'
     testLogging {

--- a/config/javadoc.opts
+++ b/config/javadoc.opts
@@ -1,0 +1,1 @@
+-notimestamp -charset UTF-8 -link https://docs.oracle.com/javase/8/docs/api/ -link http://reactivex.io/RxJava/javadoc/ -noqualifier all

--- a/src/main/java/rx/broadcast/KryoSerializer.java
+++ b/src/main/java/rx/broadcast/KryoSerializer.java
@@ -7,12 +7,7 @@ import com.esotericsoftware.kryo.io.Output;
 
 @SuppressWarnings("WeakerAccess")
 public final class KryoSerializer {
-    private final ThreadLocal<Kryo> threadLocalKryo = new ThreadLocal<Kryo>() {
-        @Override
-        protected Kryo initialValue() {
-            return new Kryo();
-        }
-    };
+    private final ThreadLocal<Kryo> threadLocalKryo = ThreadLocal.withInitial(Kryo::new);
 
     public final byte[] serialize(final Object value) {
         final Kryo kryo = threadLocalKryo.get();


### PR DESCRIPTION
This PR is preparation for releasing 1.0.0 (seeing as the lib has seen enough stable use).

Tasks:

- [x] Hide SSF and causal orderings (they'll be back once they're battle-tested)
- [x] General cleanup
- [x] Add `CONTRIBUTING.md` (closes #9)
- [x] Fix up Javadoc (closes #8)