### PR TITLE
Fix issue with Travis CI build interface names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
     - gradle build
     - gradle testJar
     - docker build -t rxb .
-    - scripts/test rx.broadcast.integration.SingleSourceFifoOrderUdpBroadcastTest 'sudo tc qdisc add dev $DOCKER_IFACE root netem delay 100ms 75ms'
+    - scripts/test rx.broadcast.integration.SingleSourceFifoOrderUdpBroadcastTest 'sudo tc qdisc add dev "${DOCKER_IFACE%%@if+([0-9])}" root netem delay 100ms 75ms'
     - scripts/test rx.broadcast.integration.BasicOrderUdpBroadcastTest
 deploy:
     provider: script

--- a/scripts/test
+++ b/scripts/test
@@ -15,7 +15,7 @@ containers=()
 for _ in {1..5}
 do
     container=$(docker_run 'org.junit.runner.JUnitCore' "$class")
-    DOCKER_IFACE=$("$DIR/veth" "$container") bash -xc "$network_command"
+    DOCKER_IFACE=$("$DIR/veth" "$container") bash -xc "shopt -s extglob; $network_command"
     containers+=($container)
 done
 


### PR DESCRIPTION
🎉 the build passes!

See also: [Bash Extended Globbing (a.k.a `extglob`)](http://www.linuxjournal.com/content/bash-extended-globbing)