### PR TITLE
Use Observable#ofType operator to filter value streams

### DIFF
--- a/src/main/java/rx/broadcast/InMemoryBroadcast.java
+++ b/src/main/java/rx/broadcast/InMemoryBroadcast.java
@@ -22,6 +22,6 @@ public final class InMemoryBroadcast implements Broadcast {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Observable<T> valuesOfType(final Class<T> clazz) {
-        return values.filter(clazz::isInstance).cast(clazz);
+        return values.ofType(clazz);
     }
 }

--- a/src/main/java/rx/broadcast/UdpBroadcast.java
+++ b/src/main/java/rx/broadcast/UdpBroadcast.java
@@ -65,7 +65,7 @@ public final class UdpBroadcast<A> implements Broadcast {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Observable<T> valuesOfType(final Class<T> clazz) {
-        return (Observable<T>) streams.computeIfAbsent(clazz, k -> values.filter(k::isInstance).cast(k).share());
+        return (Observable<T>) streams.computeIfAbsent(clazz, k -> values.ofType(k).share());
     }
 
     @SuppressWarnings({"unchecked", "UnnecessaryContinue"})


### PR DESCRIPTION
This PR updates the two Broadcast implementations to use the [`Observable#ofType(Class)`](http://reactivex.io/RxJava/javadoc/rx/Observable.html#ofType(java.lang.Class)) operator.