### PR TITLE
Add test case for SingleSourceFifoOrder#prepare

### DIFF
--- a/src/main/java/rx/broadcast/Timestamped.java
+++ b/src/main/java/rx/broadcast/Timestamped.java
@@ -1,5 +1,7 @@
 package rx.broadcast;
 
+import java.util.Objects;
+
 final class Timestamped<T> implements Comparable<Timestamped<T>> {
     @SuppressWarnings("WeakerAccess")
     public long timestamp;
@@ -24,5 +26,23 @@ final class Timestamped<T> implements Comparable<Timestamped<T>> {
     @Override
     public String toString() {
         return String.format("Timestamped{timestamp=%d, value=%s}", timestamp, value);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final Timestamped<?> timestamped = (Timestamped<?>) o;
+        return timestamp == timestamped.timestamp && Objects.equals(value, timestamped.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(timestamp, value);
     }
 }

--- a/src/test/java/rx/broadcast/SingleSourceFifoOrderTest.java
+++ b/src/test/java/rx/broadcast/SingleSourceFifoOrderTest.java
@@ -1,13 +1,13 @@
 package rx.broadcast;
 
+import org.junit.Assert;
 import org.junit.Test;
 import rx.observers.TestSubscriber;
 
 import java.util.Arrays;
 
-@SuppressWarnings("Duplicates")
+@SuppressWarnings({"Duplicates", "checkstyle:MagicNumber"})
 public class SingleSourceFifoOrderTest {
-    @SuppressWarnings({"checkstyle:magicnumber"})
     @Test
     public final void receiveMessagesInOrder() {
         final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
@@ -217,5 +217,14 @@ public class SingleSourceFifoOrderTest {
         ssf.receive(sender2, consumer::onNext, value0);
 
         consumer.assertReceivedOnNext(Arrays.asList(value0.value, value2.value, value0.value, value2.value));
+    }
+
+    @Test
+    public final void prepareValueShouldReturnTimestampedValueWithIncreasingTimestamps() {
+        final SingleSourceFifoOrder<TestValue> ssf = new SingleSourceFifoOrder<>();
+
+        Assert.assertEquals(new Timestamped<>(0, new TestValue(42)), ssf.prepare(new TestValue(42)));
+        Assert.assertEquals(new Timestamped<>(1, new TestValue(42)), ssf.prepare(new TestValue(42)));
+        Assert.assertEquals(new Timestamped<>(2, new TestValue(42)), ssf.prepare(new TestValue(42)));
     }
 }


### PR DESCRIPTION
This PR adds a test case for `SingleSourceFifoOrder#prepare`.