### PR TITLE
Fix UdpBroadcast scheduler

### DIFF
--- a/src/main/java/rx/broadcast/DaemonThreadFactory.java
+++ b/src/main/java/rx/broadcast/DaemonThreadFactory.java
@@ -1,0 +1,16 @@
+package rx.broadcast;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+
+class DaemonThreadFactory implements ThreadFactory {
+    private final AtomicLong id = new AtomicLong();
+
+    @Override
+    public final Thread newThread(final Runnable r) {
+        final Thread t = new Thread(r);
+        t.setDaemon(true);
+        t.setName("RxBroadcast-" + id.incrementAndGet());
+        return t;
+    }
+}

--- a/src/main/java/rx/broadcast/UdpBroadcast.java
+++ b/src/main/java/rx/broadcast/UdpBroadcast.java
@@ -11,6 +11,7 @@ import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
 public final class UdpBroadcast<A> implements Broadcast {
@@ -40,7 +41,9 @@ public final class UdpBroadcast<A> implements Broadcast {
     ) {
         this.socket = socket;
         this.order = order;
-        this.values = Observable.<Object>create(this::receive).subscribeOn(Schedulers.io()).share();
+        this.values = Observable.<Object>create(this::receive)
+            .subscribeOn(Schedulers.from(Executors.newSingleThreadScheduledExecutor(new DaemonThreadFactory())))
+            .share();
         this.serializer = new KryoSerializer();
         this.streams = new ConcurrentHashMap<>();
         this.destinationAddress = destinationAddress;


### PR DESCRIPTION
As of RxJava v1.1.9, `Schedulers.io()` will not reuse threads that are blocked, resulting in `this::receive` being called from multiple threads (see also #54).