### PR TITLE
Upgrade compiler warning to errors and fix errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 allprojects {
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {
-            options.compilerArgs << '-Xlint:all' << '-Xdiags:verbose'
+            options.compilerArgs << '-Xlint:all' << '-Xdiags:verbose' << '-Werror'
         }
     }
 }

--- a/src/main/java/rx/broadcast/UdpBroadcast.java
+++ b/src/main/java/rx/broadcast/UdpBroadcast.java
@@ -23,7 +23,7 @@ public final class UdpBroadcast<A> implements Broadcast {
 
     private final Observable<Object> values;
 
-    private final ConcurrentHashMap<Class, Observable> streams;
+    private final ConcurrentHashMap<Class<?>, Observable<?>> streams;
 
     private final KryoSerializer serializer;
 

--- a/src/main/java/rx/broadcast/UdpBroadcast.java
+++ b/src/main/java/rx/broadcast/UdpBroadcast.java
@@ -41,7 +41,7 @@ public final class UdpBroadcast<A> implements Broadcast {
     ) {
         this.socket = socket;
         this.order = order;
-        this.values = Observable.<Object>create(this::receive)
+        this.values = Observable.<Object>unsafeCreate(this::receive)
             .subscribeOn(Schedulers.from(Executors.newSingleThreadScheduledExecutor(new DaemonThreadFactory())))
             .share();
         this.serializer = new KryoSerializer();


### PR DESCRIPTION
This PR upgrades javac warnings (`-Xlint:all`) to compiler errors and fixes them.