### PR TITLE
Adapterize serialization for objects in transit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpSingleSourceFifoOrder
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpSingleSourceFifoOrderKryoSerializer
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpSingleSourceFifoOrderObjectSerializer
+    - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpSingleSourceFifoOrderProtobufSerializer
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrder
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrderKryoSerializer
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrderObjectSerializer

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ script:
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrder
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrderKryoSerializer
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrderObjectSerializer
+    - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrderProtobufSerializer
 deploy:
     provider: script
     script: scripts/deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,11 @@ script:
     - scripts/test rx.broadcast.integration.SingleSourceFifoOrderUdpBroadcastTest 'sudo tc qdisc add dev "${DOCKER_IFACE%%@if+([0-9])}" root netem delay 100ms 75ms'
     - scripts/test rx.broadcast.integration.BasicOrderUdpBroadcastTest
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpBasicOrder
+    - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpBasicOrderKryoSerializer
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpSingleSourceFifoOrder
+    - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpSingleSourceFifoOrderKryoSerializer
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrder
+    - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrderKryoSerializer
 deploy:
     provider: script
     script: scripts/deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,13 @@ script:
     - scripts/test rx.broadcast.integration.BasicOrderUdpBroadcastTest
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpBasicOrder
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpBasicOrderKryoSerializer
+    - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpBasicOrderObjectSerializer
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpSingleSourceFifoOrder
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpSingleSourceFifoOrderKryoSerializer
+    - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpSingleSourceFifoOrderObjectSerializer
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrder
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrderKryoSerializer
+    - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrderObjectSerializer
 deploy:
     provider: script
     script: scripts/deploy

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ repositories {
 
 dependencies {
     compile 'com.esotericsoftware:kryo:3.0.3'
+    compile 'com.google.protobuf:protobuf-java:3.3.0'
     compile 'io.reactivex:rxjava:1.3.0'
     testCompile 'junit:junit:4.12'
 }

--- a/src/main/java/rx/broadcast/CausalOrderProtobufSerializer.java
+++ b/src/main/java/rx/broadcast/CausalOrderProtobufSerializer.java
@@ -1,0 +1,125 @@
+package rx.broadcast;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldOptions;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Parser;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class CausalOrderProtobufSerializer<T> implements Serializer<VectorTimestamped<T>> {
+    private static final String MESSAGE_NAME = "VectorTimestamped";
+
+    private static final String IDS_FIELD_NAME = "ids";
+
+    private static final String TIMESTAMPS_FIELD_NAME = "timestamps";
+
+    private static final String VALUE_FIELD_NAME = "value";
+
+    private static final int IDS_FIELD_NUMBER = 1;
+
+    private static final int TIMESTAMPS_FIELD_NUMBER = 2;
+
+    private static final int VALUE_FIELD_NUMBER = 3;
+
+    private final FieldDescriptor ids;
+
+    private final FieldDescriptor timestamps;
+
+    private final FieldDescriptor value;
+
+    private final DynamicMessage.Builder messageBuilder;
+
+    private final Parser<DynamicMessage> messageParser;
+
+    private final Serializer<T> objectSerializer;
+
+    public CausalOrderProtobufSerializer(final Serializer<T> objectSerializer) {
+        this.objectSerializer = objectSerializer;
+        try {
+            final FileDescriptorProto timestampedMessageFile = FileDescriptorProto.newBuilder()
+                .addMessageType(
+                    DescriptorProto.newBuilder()
+                        .setName(MESSAGE_NAME)
+                        .addField(
+                            FieldDescriptorProto.newBuilder()
+                                .setLabel(FieldDescriptorProto.Label.LABEL_REPEATED)
+                                .setName(IDS_FIELD_NAME)
+                                .setNumber(IDS_FIELD_NUMBER)
+                                .setOptions(FieldOptions.newBuilder()
+                                    .setPacked(true))
+                                .setType(FieldDescriptorProto.Type.TYPE_UINT64))
+                        .addField(
+                            FieldDescriptorProto.newBuilder()
+                                .setLabel(FieldDescriptorProto.Label.LABEL_REPEATED)
+                                .setName(TIMESTAMPS_FIELD_NAME)
+                                .setNumber(TIMESTAMPS_FIELD_NUMBER)
+                                .setOptions(FieldOptions.newBuilder()
+                                    .setPacked(true))
+                                .setType(FieldDescriptorProto.Type.TYPE_UINT64))
+                        .addField(
+                            FieldDescriptorProto.newBuilder()
+                                .setName(VALUE_FIELD_NAME)
+                                .setNumber(VALUE_FIELD_NUMBER)
+                                .setType(FieldDescriptorProto.Type.TYPE_BYTES)))
+                .build();
+            final Descriptor message = FileDescriptor
+                .buildFrom(timestampedMessageFile, new FileDescriptor[0])
+                .findMessageTypeByName(MESSAGE_NAME);
+            this.ids = message.findFieldByName(IDS_FIELD_NAME);
+            this.timestamps = message.findFieldByName(TIMESTAMPS_FIELD_NAME);
+            this.value = message.findFieldByName(VALUE_FIELD_NAME);
+            this.messageBuilder = DynamicMessage.newBuilder(message);
+            this.messageParser = messageBuilder.buildPartial().getParserForType();
+        } catch (final DescriptorValidationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public final VectorTimestamped<T> decode(final byte[] data) {
+        try {
+            final DynamicMessage message = messageParser.parseFrom(data);
+            final byte[] bytes = ((ByteString) message.getField(this.value)).toByteArray();
+            final T value = objectSerializer.decode(bytes);
+            final int idsCount = message.getRepeatedFieldCount(this.ids);
+            final int timestampsCount = message.getRepeatedFieldCount(this.timestamps);
+            final long[] ids = new long[idsCount];
+            final long[] timestamps = new long[timestampsCount];
+
+            for (int i = 0; i < idsCount; i++) {
+                ids[i] = (long) message.getRepeatedField(this.ids, i);
+            }
+            for (int i = 0; i < timestampsCount; i++) {
+                timestamps[i] = (long) message.getRepeatedField(this.timestamps, i);
+            }
+
+            return new VectorTimestamped<>(value, new VectorTimestamp(ids, timestamps));
+        } catch (final InvalidProtocolBufferException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public final byte[] encode(final VectorTimestamped<T> data) {
+        final DynamicMessage.Builder builder = messageBuilder
+            .setField(this.value, objectSerializer.encode(data.value));
+
+        final AtomicInteger i = new AtomicInteger(0);
+        data.timestamp.stream().forEachOrdered(entry -> {
+            builder.setRepeatedField(this.ids, i.get(), entry.id);
+            builder.setRepeatedField(this.timestamps, i.get(), entry.timestamp);
+            i.incrementAndGet();
+        });
+
+        return builder.build().toByteArray();
+    }
+}

--- a/src/main/java/rx/broadcast/KryoSerializer.java
+++ b/src/main/java/rx/broadcast/KryoSerializer.java
@@ -6,7 +6,7 @@ import com.esotericsoftware.kryo.io.FastOutput;
 import com.esotericsoftware.kryo.io.Output;
 
 @SuppressWarnings("WeakerAccess")
-public final class KryoSerializer implements Serializer<Object> {
+public final class KryoSerializer<T> implements Serializer<T> {
     private final ThreadLocal<Kryo> threadLocalKryo = ThreadLocal.withInitial(Kryo::new);
 
     public final byte[] serialize(final Object value) {
@@ -22,12 +22,13 @@ public final class KryoSerializer implements Serializer<Object> {
     }
 
     @Override
-    public final Object decode(final byte[] data) {
-        return deserialize(data);
+    @SuppressWarnings("unchecked")
+    public final T decode(final byte[] data) {
+        return (T) deserialize(data);
     }
 
     @Override
-    public final byte[] encode(final Object data) {
+    public final byte[] encode(final T data) {
         return serialize(data);
     }
 }

--- a/src/main/java/rx/broadcast/KryoSerializer.java
+++ b/src/main/java/rx/broadcast/KryoSerializer.java
@@ -6,7 +6,7 @@ import com.esotericsoftware.kryo.io.FastOutput;
 import com.esotericsoftware.kryo.io.Output;
 
 @SuppressWarnings("WeakerAccess")
-public final class KryoSerializer {
+public final class KryoSerializer implements Serializer<Object> {
     private final ThreadLocal<Kryo> threadLocalKryo = ThreadLocal.withInitial(Kryo::new);
 
     public final byte[] serialize(final Object value) {
@@ -19,5 +19,15 @@ public final class KryoSerializer {
     public final Object deserialize(final byte[] bytes) {
         final Kryo kryo = threadLocalKryo.get();
         return kryo.readClassAndObject(new FastInput(bytes));
+    }
+
+    @Override
+    public final Object decode(final byte[] data) {
+        return deserialize(data);
+    }
+
+    @Override
+    public final byte[] encode(final Object data) {
+        return serialize(data);
     }
 }

--- a/src/main/java/rx/broadcast/ObjectSerializer.java
+++ b/src/main/java/rx/broadcast/ObjectSerializer.java
@@ -1,0 +1,33 @@
+package rx.broadcast;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+public final class ObjectSerializer<T> implements Serializer<T> {
+    @Override
+    @SuppressWarnings("unchecked")
+    public final T decode(final byte[] data) {
+        try {
+            final ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(data));
+            return (T) ois.readObject();
+        } catch (final ClassNotFoundException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public final byte[] encode(final T data) {
+        try {
+            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            final ObjectOutputStream oos = new ObjectOutputStream(baos);
+            oos.writeObject(data);
+            oos.flush();
+            return baos.toByteArray();
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/rx/broadcast/Serializer.java
+++ b/src/main/java/rx/broadcast/Serializer.java
@@ -1,0 +1,7 @@
+package rx.broadcast;
+
+public interface Serializer<T> {
+    T decode(byte[] data);
+
+    byte[] encode(T data);
+}

--- a/src/main/java/rx/broadcast/SingleSourceFifoOrderProtobufSerializer.java
+++ b/src/main/java/rx/broadcast/SingleSourceFifoOrderProtobufSerializer.java
@@ -1,0 +1,87 @@
+package rx.broadcast;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Parser;
+
+public final class SingleSourceFifoOrderProtobufSerializer<T> implements Serializer<Timestamped<T>> {
+    private static final String MESSAGE_NAME = "Timestamped";
+
+    private static final String TIMESTAMP_FIELD_NAME = "timestamp";
+
+    private static final String VALUE_FIELD_NAME = "value";
+
+    private static final int TIMESTAMP_FIELD_NUMBER = 1;
+
+    private static final int VALUE_FIELD_NUMBER = 2;
+
+    private final FieldDescriptor timestampedMessageField;
+
+    private final FieldDescriptor valueMessageField;
+
+    private final DynamicMessage.Builder messageBuilder;
+
+    private final Parser<DynamicMessage> messageParser;
+
+    private final Serializer<T> objectSerializer;
+
+    public SingleSourceFifoOrderProtobufSerializer(final Serializer<T> objectSerializer) {
+        this.objectSerializer = objectSerializer;
+        try {
+            final FileDescriptorProto timestampedMessageFile = FileDescriptorProto.newBuilder()
+                .addMessageType(
+                    DescriptorProto.newBuilder()
+                        .setName(MESSAGE_NAME)
+                        .addField(
+                            FieldDescriptorProto.newBuilder()
+                                .setName(TIMESTAMP_FIELD_NAME)
+                                .setNumber(TIMESTAMP_FIELD_NUMBER)
+                                .setType(FieldDescriptorProto.Type.TYPE_INT64))
+                        .addField(
+                            FieldDescriptorProto.newBuilder()
+                                .setName(VALUE_FIELD_NAME)
+                                .setNumber(VALUE_FIELD_NUMBER)
+                                .setType(FieldDescriptorProto.Type.TYPE_BYTES)))
+                .build();
+            final Descriptor message = FileDescriptor
+                .buildFrom(timestampedMessageFile, new FileDescriptor[0])
+                .findMessageTypeByName(MESSAGE_NAME);
+            this.timestampedMessageField = message.findFieldByName(TIMESTAMP_FIELD_NAME);
+            this.valueMessageField = message.findFieldByName(VALUE_FIELD_NAME);
+            this.messageBuilder = DynamicMessage.newBuilder(message);
+            this.messageParser = messageBuilder.buildPartial().getParserForType();
+        } catch (final DescriptorValidationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public final Timestamped<T> decode(final byte[] data) {
+        try {
+            final DynamicMessage message = messageParser.parseFrom(data);
+            final long timestamp = (long) message.getField(timestampedMessageField);
+            final byte[] bytes = ((ByteString) message.getField(valueMessageField)).toByteArray();
+            final T value = objectSerializer.decode(bytes);
+            return new Timestamped<>(timestamp, value);
+        } catch (final InvalidProtocolBufferException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public final byte[] encode(final Timestamped<T> data) {
+        return messageBuilder
+            .setField(timestampedMessageField, data.timestamp)
+            .setField(valueMessageField, objectSerializer.encode(data.value))
+            .build()
+            .toByteArray();
+    }
+}

--- a/src/main/java/rx/broadcast/Timestamped.java
+++ b/src/main/java/rx/broadcast/Timestamped.java
@@ -9,7 +9,7 @@ final class Timestamped<T> implements Comparable<Timestamped<T>> {
     public T value;
 
     @SuppressWarnings("unused")
-    public Timestamped() {
+    Timestamped() {
 
     }
 

--- a/src/main/java/rx/broadcast/Timestamped.java
+++ b/src/main/java/rx/broadcast/Timestamped.java
@@ -1,8 +1,11 @@
 package rx.broadcast;
 
+import java.io.Serializable;
 import java.util.Objects;
 
-final class Timestamped<T> implements Comparable<Timestamped<T>> {
+final class Timestamped<T> implements Comparable<Timestamped<T>>, Serializable {
+    private static final long serialVersionUID = 114L;
+
     @SuppressWarnings("WeakerAccess")
     public long timestamp;
 

--- a/src/main/java/rx/broadcast/UdpBroadcast.java
+++ b/src/main/java/rx/broadcast/UdpBroadcast.java
@@ -59,7 +59,7 @@ public final class UdpBroadcast<A> implements Broadcast {
         final int destinationPort,
         final BroadcastOrder<A, Object> order
     ) {
-        this(socket, destinationAddress, destinationPort, (Serializer<A>) new KryoSerializer(), order);
+        this(socket, destinationAddress, destinationPort, new KryoSerializer<>(), order);
     }
 
     @Override

--- a/src/main/java/rx/broadcast/UdpBroadcast.java
+++ b/src/main/java/rx/broadcast/UdpBroadcast.java
@@ -37,17 +37,28 @@ public final class UdpBroadcast<A> implements Broadcast {
         final DatagramSocket socket,
         final InetAddress destinationAddress,
         final int destinationPort,
-        final BroadcastOrder<A, Object> order
+        final BroadcastOrder<A, Object> order,
+        final Serializer<A> serializer
     ) {
         this.socket = socket;
         this.order = order;
         this.values = Observable.<Object>unsafeCreate(this::receive)
             .subscribeOn(Schedulers.from(Executors.newSingleThreadScheduledExecutor(new DaemonThreadFactory())))
             .share();
-        this.serializer = new KryoSerializer();
+        this.serializer = serializer;
         this.streams = new ConcurrentHashMap<>();
         this.destinationAddress = destinationAddress;
         this.destinationPort = destinationPort;
+    }
+
+    @SuppressWarnings("unchecked")
+    public UdpBroadcast(
+        final DatagramSocket socket,
+        final InetAddress destinationAddress,
+        final int destinationPort,
+        final BroadcastOrder<A, Object> order
+    ) {
+        this(socket, destinationAddress, destinationPort, order, (Serializer<A>) new KryoSerializer());
     }
 
     @Override

--- a/src/main/java/rx/broadcast/UdpBroadcast.java
+++ b/src/main/java/rx/broadcast/UdpBroadcast.java
@@ -33,6 +33,7 @@ public final class UdpBroadcast<A> implements Broadcast {
 
     private final BroadcastOrder<A, Object> order;
 
+    @SuppressWarnings("WeakerAccess")
     public UdpBroadcast(
         final DatagramSocket socket,
         final InetAddress destinationAddress,

--- a/src/main/java/rx/broadcast/UdpBroadcast.java
+++ b/src/main/java/rx/broadcast/UdpBroadcast.java
@@ -38,8 +38,8 @@ public final class UdpBroadcast<A> implements Broadcast {
         final DatagramSocket socket,
         final InetAddress destinationAddress,
         final int destinationPort,
-        final BroadcastOrder<A, Object> order,
-        final Serializer<A> serializer
+        final Serializer<A> serializer,
+        final BroadcastOrder<A, Object> order
     ) {
         this.socket = socket;
         this.order = order;
@@ -59,7 +59,7 @@ public final class UdpBroadcast<A> implements Broadcast {
         final int destinationPort,
         final BroadcastOrder<A, Object> order
     ) {
-        this(socket, destinationAddress, destinationPort, order, (Serializer<A>) new KryoSerializer());
+        this(socket, destinationAddress, destinationPort, (Serializer<A>) new KryoSerializer(), order);
     }
 
     @Override

--- a/src/main/java/rx/broadcast/UdpBroadcast.java
+++ b/src/main/java/rx/broadcast/UdpBroadcast.java
@@ -83,7 +83,6 @@ public final class UdpBroadcast<A> implements Broadcast {
         return (Observable<T>) streams.computeIfAbsent(clazz, k -> values.ofType(k).share());
     }
 
-    @SuppressWarnings({"unchecked"})
     private void receive(final Subscriber<Object> subscriber) {
         final Consumer<Object> consumer = subscriber::onNext;
         while (true) {
@@ -105,7 +104,7 @@ public final class UdpBroadcast<A> implements Broadcast {
             final long sender = ByteBuffer.allocate(BYTES_LONG).put(address.getAddress()).putInt(port).getLong(0);
             final byte[] data = Arrays.copyOf(buffer, packet.getLength());
             try {
-                order.receive(sender, consumer, (A) serializer.decode(data));
+                order.receive(sender, consumer, serializer.decode(data));
             } catch (final RuntimeException e) {
                 /* This is bad and I feel bad about it. See issue #47 for plans to fix this. */
             }

--- a/src/main/java/rx/broadcast/VectorTimestamp.java
+++ b/src/main/java/rx/broadcast/VectorTimestamp.java
@@ -1,9 +1,12 @@
 package rx.broadcast;
 
+import java.io.Serializable;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-final class VectorTimestamp {
+final class VectorTimestamp implements Serializable {
+    private static final long serialVersionUID = 114L;
+
     private long[] ids;
 
     private long[] timestamps;

--- a/src/main/java/rx/broadcast/VectorTimestamped.java
+++ b/src/main/java/rx/broadcast/VectorTimestamped.java
@@ -11,7 +11,7 @@ final class VectorTimestamped<T> {
     public T value;
 
     @SuppressWarnings("unused")
-    public VectorTimestamped() {
+    VectorTimestamped() {
 
     }
 

--- a/src/main/java/rx/broadcast/VectorTimestamped.java
+++ b/src/main/java/rx/broadcast/VectorTimestamped.java
@@ -1,11 +1,15 @@
 package rx.broadcast;
 
+import java.io.Serializable;
+
 /**
  * Represents a value of type {@code T} that has been timestamped with a {@code VectorTimestamp}.
  * @param <T> the type of the timestamped value.
  */
 @SuppressWarnings("WeakerAccess")
-final class VectorTimestamped<T> {
+final class VectorTimestamped<T> implements Serializable {
+    private static final long serialVersionUID = 114L;
+
     public VectorTimestamp timestamp;
 
     public T value;

--- a/src/main/proto/rx/broadcast/Timestamped.proto
+++ b/src/main/proto/rx/broadcast/Timestamped.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+
+option java_package = "rx.broadcast";
+option java_outer_classname = "ProtobufTimestamped";
+
+message Timestamped {
+    required uint64 timestamp = 1;
+    required bytes value = 2;
+}

--- a/src/main/proto/rx/broadcast/VectorTimestamped.proto
+++ b/src/main/proto/rx/broadcast/VectorTimestamped.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+
+option java_package = "rx.broadcast";
+option java_outer_classname = "ProtobufVectorTimestamped";
+
+message VectorTimestamped {
+    repeated uint64 ids = 1 [packed=true];
+    repeated uint64 timestamps = 2 [packed=true];
+    required bytes value = 3;
+}

--- a/src/test/java/rx/broadcast/integration/pp/Ping.java
+++ b/src/test/java/rx/broadcast/integration/pp/Ping.java
@@ -6,7 +6,7 @@ public final class Ping {
     @SuppressWarnings("WeakerAccess")
     public int value;
 
-    public Ping(final int value) {
+    Ping(final int value) {
         this.value = value;
     }
 

--- a/src/test/java/rx/broadcast/integration/pp/Ping.java
+++ b/src/test/java/rx/broadcast/integration/pp/Ping.java
@@ -1,8 +1,11 @@
 package rx.broadcast.integration.pp;
 
+import java.io.Serializable;
 import java.util.Objects;
 
-public final class Ping {
+public final class Ping implements Serializable {
+    private static final long serialVersionUID = 114L;
+
     @SuppressWarnings("WeakerAccess")
     public int value;
 

--- a/src/test/java/rx/broadcast/integration/pp/PingPongUdpBasicOrderKryoSerializer.java
+++ b/src/test/java/rx/broadcast/integration/pp/PingPongUdpBasicOrderKryoSerializer.java
@@ -1,0 +1,81 @@
+package rx.broadcast.integration.pp;
+
+import org.junit.Test;
+import rx.Observable;
+import rx.broadcast.BasicOrder;
+import rx.broadcast.Broadcast;
+import rx.broadcast.KryoSerializer;
+import rx.broadcast.UdpBroadcast;
+import rx.observers.TestSubscriber;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+
+public class PingPongUdpBasicOrderKryoSerializer {
+    private static final int MESSAGE_COUNT = 100;
+
+    private static final long TIMEOUT = 30;
+
+    /**
+     * Receive a PING and respond with a PONG.
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    @Test
+    public final void recv() throws SocketException, UnknownHostException {
+        final int port = Integer.valueOf(System.getProperty("port"));
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, port, new KryoSerializer<>(), new BasicOrder<>());
+
+        final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
+
+        broadcast.valuesOfType(Ping.class)
+            .doOnNext(System.out::println)
+            .concatMap(ping ->
+                broadcast.send(new Pong(ping.value))
+                    // Once we've sent the response, we can emit the PING value to the subscriber.
+                    // The cast here is a hack to allow us to concatenate a PING onto the stream.
+                    // Where this is an `Observable<Void>` we know we won't get anything that needs to be casted.
+                    .cast(Ping.class)
+                    .concatWith(Observable.just(ping))
+                    .doOnCompleted(() -> System.out.println("Sent PONG")))
+            .take(MESSAGE_COUNT)
+            .subscribe(subscriber);
+
+        subscriber.awaitTerminalEventAndUnsubscribeOnTimeout(TIMEOUT, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(MESSAGE_COUNT);
+    }
+
+    /**
+     * Send a set PING messages to the receiver, expecting PONG messages in response.
+     * @param args the command line arguments passed to the program
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
+        final int port = Integer.valueOf(System.getProperty("port"));
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, port, new KryoSerializer<>(), new BasicOrder<>());
+
+        Observable.range(1, MESSAGE_COUNT)
+            .map(Ping::new)
+            .doOnNext(System.out::println)
+            .concatMap(value ->
+                broadcast.send(value)
+                    .doOnCompleted(() -> System.out.printf("Sent %s%n", value))
+                    .cast(Pong.class)
+                    .concatWith(broadcast.valuesOfType(Pong.class).first()))
+            .timeout(TIMEOUT, TimeUnit.SECONDS)
+            .toBlocking()
+            .subscribe(pong ->
+                System.out.printf("Received %s%n", pong));
+    }
+}

--- a/src/test/java/rx/broadcast/integration/pp/PingPongUdpBasicOrderObjectSerializer.java
+++ b/src/test/java/rx/broadcast/integration/pp/PingPongUdpBasicOrderObjectSerializer.java
@@ -1,0 +1,81 @@
+package rx.broadcast.integration.pp;
+
+import org.junit.Test;
+import rx.Observable;
+import rx.broadcast.BasicOrder;
+import rx.broadcast.Broadcast;
+import rx.broadcast.ObjectSerializer;
+import rx.broadcast.UdpBroadcast;
+import rx.observers.TestSubscriber;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+
+public class PingPongUdpBasicOrderObjectSerializer {
+    private static final int MESSAGE_COUNT = 100;
+
+    private static final long TIMEOUT = 30;
+
+    /**
+     * Receive a PING and respond with a PONG.
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    @Test
+    public final void recv() throws SocketException, UnknownHostException {
+        final int port = Integer.valueOf(System.getProperty("port"));
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, port, new ObjectSerializer<>(), new BasicOrder<>());
+
+        final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
+
+        broadcast.valuesOfType(Ping.class)
+            .doOnNext(System.out::println)
+            .concatMap(ping ->
+                broadcast.send(new Pong(ping.value))
+                    // Once we've sent the response, we can emit the PING value to the subscriber.
+                    // The cast here is a hack to allow us to concatenate a PING onto the stream.
+                    // Where this is an `Observable<Void>` we know we won't get anything that needs to be casted.
+                    .cast(Ping.class)
+                    .concatWith(Observable.just(ping))
+                    .doOnCompleted(() -> System.out.println("Sent PONG")))
+            .take(MESSAGE_COUNT)
+            .subscribe(subscriber);
+
+        subscriber.awaitTerminalEventAndUnsubscribeOnTimeout(TIMEOUT, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(MESSAGE_COUNT);
+    }
+
+    /**
+     * Send a set PING messages to the receiver, expecting PONG messages in response.
+     * @param args the command line arguments passed to the program
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
+        final int port = Integer.valueOf(System.getProperty("port"));
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, port, new ObjectSerializer<>(), new BasicOrder<>());
+
+        Observable.range(1, MESSAGE_COUNT)
+            .map(Ping::new)
+            .doOnNext(System.out::println)
+            .concatMap(value ->
+                broadcast.send(value)
+                    .doOnCompleted(() -> System.out.printf("Sent %s%n", value))
+                    .cast(Pong.class)
+                    .concatWith(broadcast.valuesOfType(Pong.class).first()))
+            .timeout(TIMEOUT, TimeUnit.SECONDS)
+            .toBlocking()
+            .subscribe(pong ->
+                System.out.printf("Received %s%n", pong));
+    }
+}

--- a/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrderKryoSerializer.java
+++ b/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrderKryoSerializer.java
@@ -1,0 +1,95 @@
+package rx.broadcast.integration.pp;
+
+import org.junit.Test;
+import rx.Observable;
+import rx.broadcast.Broadcast;
+import rx.broadcast.CausalOrder;
+import rx.broadcast.KryoSerializer;
+import rx.broadcast.UdpBroadcast;
+import rx.observers.TestSubscriber;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+
+@SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:AvoidInlineConditionals"})
+public class PingPongUdpCausalOrderKryoSerializer {
+    private static final int MESSAGE_COUNT = 100;
+
+    private static final long TIMEOUT = 30;
+
+    /**
+     * Receive a PING and respond with a PONG.
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    @Test
+    public final void recv() throws SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new KryoSerializer<>(), new CausalOrder<>());
+        final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
+
+        broadcast.valuesOfType(Ping.class)
+            .doOnNext(System.out::println)
+            .concatMap(ping ->
+                broadcast.send(new Pong(ping.value))
+                    // Once we've sent the response, we can emit the PING value to the subscriber.
+                    // The cast here is a hack to allow us to concatenate a PING onto the stream.
+                    // Where this is an `Observable<Void>` we know we won't get anything that needs to be casted.
+                    .cast(Ping.class)
+                    .concatWith(Observable.just(ping))
+                    .doOnCompleted(() -> System.out.println("Sent PONG")))
+            .take(MESSAGE_COUNT)
+            .subscribe(subscriber);
+
+        subscriber.awaitTerminalEventAndUnsubscribeOnTimeout(TIMEOUT, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(MESSAGE_COUNT);
+    }
+
+    /**
+     * Send a set PING messages to the receiver, expecting PONG messages in response.
+     * @param args the command line arguments passed to the program
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new KryoSerializer<>(), new CausalOrder<>());
+
+        Observable.range(1, MESSAGE_COUNT)
+            .map(Ping::new)
+            .doOnNext(System.out::println)
+            .concatMap(value ->
+                broadcast.send(value)
+                    .doOnCompleted(() -> System.out.printf("Sent %s%n", value))
+                    .cast(Pong.class)
+                    .concatWith(broadcast.valuesOfType(Pong.class).first()))
+            .timeout(TIMEOUT, TimeUnit.SECONDS)
+            .toBlocking()
+            .subscribe(pong ->
+                System.out.printf("Received %s%n", pong));
+    }
+}

--- a/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrderObjectSerializer.java
+++ b/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrderObjectSerializer.java
@@ -1,0 +1,95 @@
+package rx.broadcast.integration.pp;
+
+import org.junit.Test;
+import rx.Observable;
+import rx.broadcast.Broadcast;
+import rx.broadcast.CausalOrder;
+import rx.broadcast.ObjectSerializer;
+import rx.broadcast.UdpBroadcast;
+import rx.observers.TestSubscriber;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+
+@SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:AvoidInlineConditionals"})
+public class PingPongUdpCausalOrderObjectSerializer {
+    private static final int MESSAGE_COUNT = 100;
+
+    private static final long TIMEOUT = 30;
+
+    /**
+     * Receive a PING and respond with a PONG.
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    @Test
+    public final void recv() throws SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new ObjectSerializer<>(), new CausalOrder<>());
+        final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
+
+        broadcast.valuesOfType(Ping.class)
+            .doOnNext(System.out::println)
+            .concatMap(ping ->
+                broadcast.send(new Pong(ping.value))
+                    // Once we've sent the response, we can emit the PING value to the subscriber.
+                    // The cast here is a hack to allow us to concatenate a PING onto the stream.
+                    // Where this is an `Observable<Void>` we know we won't get anything that needs to be casted.
+                    .cast(Ping.class)
+                    .concatWith(Observable.just(ping))
+                    .doOnCompleted(() -> System.out.println("Sent PONG")))
+            .take(MESSAGE_COUNT)
+            .subscribe(subscriber);
+
+        subscriber.awaitTerminalEventAndUnsubscribeOnTimeout(TIMEOUT, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(MESSAGE_COUNT);
+    }
+
+    /**
+     * Send a set PING messages to the receiver, expecting PONG messages in response.
+     * @param args the command line arguments passed to the program
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new ObjectSerializer<>(), new CausalOrder<>());
+
+        Observable.range(1, MESSAGE_COUNT)
+            .map(Ping::new)
+            .doOnNext(System.out::println)
+            .concatMap(value ->
+                broadcast.send(value)
+                    .doOnCompleted(() -> System.out.printf("Sent %s%n", value))
+                    .cast(Pong.class)
+                    .concatWith(broadcast.valuesOfType(Pong.class).first()))
+            .timeout(TIMEOUT, TimeUnit.SECONDS)
+            .toBlocking()
+            .subscribe(pong ->
+                System.out.printf("Received %s%n", pong));
+    }
+}

--- a/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrderProtobufSerializer.java
+++ b/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrderProtobufSerializer.java
@@ -1,0 +1,99 @@
+package rx.broadcast.integration.pp;
+
+import org.junit.Test;
+import rx.Observable;
+import rx.broadcast.Broadcast;
+import rx.broadcast.CausalOrder;
+import rx.broadcast.CausalOrderProtobufSerializer;
+import rx.broadcast.ObjectSerializer;
+import rx.broadcast.Serializer;
+import rx.broadcast.UdpBroadcast;
+import rx.observers.TestSubscriber;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+
+@SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:AvoidInlineConditionals"})
+public class PingPongUdpCausalOrderProtobufSerializer {
+    private static final int MESSAGE_COUNT = 100;
+
+    private static final long TIMEOUT = 30;
+
+    /**
+     * Receive a PING and respond with a PONG.
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    @Test
+    public final void recv() throws SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Serializer<Object> s = new ObjectSerializer<>();
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new CausalOrderProtobufSerializer<>(s), new CausalOrder<>());
+        final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
+
+        broadcast.valuesOfType(Ping.class)
+            .doOnNext(System.out::println)
+            .concatMap(ping ->
+                broadcast.send(new Pong(ping.value))
+                    // Once we've sent the response, we can emit the PING value to the subscriber.
+                    // The cast here is a hack to allow us to concatenate a PING onto the stream.
+                    // Where this is an `Observable<Void>` we know we won't get anything that needs to be casted.
+                    .cast(Ping.class)
+                    .concatWith(Observable.just(ping))
+                    .doOnCompleted(() -> System.out.println("Sent PONG")))
+            .take(MESSAGE_COUNT)
+            .subscribe(subscriber);
+
+        subscriber.awaitTerminalEventAndUnsubscribeOnTimeout(TIMEOUT, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(MESSAGE_COUNT);
+    }
+
+    /**
+     * Send a set PING messages to the receiver, expecting PONG messages in response.
+     * @param args the command line arguments passed to the program
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Serializer<Object> s = new ObjectSerializer<>();
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new CausalOrderProtobufSerializer<>(s), new CausalOrder<>());
+
+        Observable.range(1, MESSAGE_COUNT)
+            .map(Ping::new)
+            .doOnNext(System.out::println)
+            .concatMap(value ->
+                broadcast.send(value)
+                    .doOnCompleted(() -> System.out.printf("Sent %s%n", value))
+                    .cast(Pong.class)
+                    .concatWith(broadcast.valuesOfType(Pong.class).first()))
+            .timeout(TIMEOUT, TimeUnit.SECONDS)
+            .toBlocking()
+            .subscribe(pong ->
+                System.out.printf("Received %s%n", pong));
+    }
+}

--- a/src/test/java/rx/broadcast/integration/pp/PingPongUdpSingleSourceFifoOrderKryoSerializer.java
+++ b/src/test/java/rx/broadcast/integration/pp/PingPongUdpSingleSourceFifoOrderKryoSerializer.java
@@ -1,0 +1,95 @@
+package rx.broadcast.integration.pp;
+
+import org.junit.Test;
+import rx.Observable;
+import rx.broadcast.Broadcast;
+import rx.broadcast.KryoSerializer;
+import rx.broadcast.SingleSourceFifoOrder;
+import rx.broadcast.UdpBroadcast;
+import rx.observers.TestSubscriber;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+
+@SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:LineLength", "checkstyle:AvoidInlineConditionals"})
+public class PingPongUdpSingleSourceFifoOrderKryoSerializer {
+    private static final int MESSAGE_COUNT = 100;
+
+    private static final long TIMEOUT = 30;
+
+    /**
+     * Receive a PING and respond with a PONG.
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    @Test
+    public final void recv() throws SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new KryoSerializer<>(), new SingleSourceFifoOrder<>());
+        final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
+
+        broadcast.valuesOfType(Ping.class)
+            .doOnNext(System.out::println)
+            .concatMap(ping ->
+                broadcast.send(new Pong(ping.value))
+                    // Once we've sent the response, we can emit the PING value to the subscriber.
+                    // The cast here is a hack to allow us to concatenate a PING onto the stream.
+                    // Where this is an `Observable<Void>` we know we won't get anything that needs to be casted.
+                    .cast(Ping.class)
+                    .concatWith(Observable.just(ping))
+                    .doOnCompleted(() -> System.out.println("Sent PONG")))
+            .take(MESSAGE_COUNT)
+            .subscribe(subscriber);
+
+        subscriber.awaitTerminalEventAndUnsubscribeOnTimeout(TIMEOUT, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(MESSAGE_COUNT);
+    }
+
+    /**
+     * Send a set PING messages to the receiver, expecting PONG messages in response.
+     * @param args the command line arguments passed to the program
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new KryoSerializer<>(), new SingleSourceFifoOrder<>());
+
+        Observable.range(1, MESSAGE_COUNT)
+            .map(Ping::new)
+            .doOnNext(System.out::println)
+            .concatMap(value ->
+                broadcast.send(value)
+                    .doOnCompleted(() -> System.out.printf("Sent %s%n", value))
+                    .cast(Pong.class)
+                    .concatWith(broadcast.valuesOfType(Pong.class).first()))
+            .timeout(TIMEOUT, TimeUnit.SECONDS)
+            .toBlocking()
+            .subscribe(pong ->
+                System.out.printf("Received %s%n", pong));
+    }
+}

--- a/src/test/java/rx/broadcast/integration/pp/PingPongUdpSingleSourceFifoOrderObjectSerializer.java
+++ b/src/test/java/rx/broadcast/integration/pp/PingPongUdpSingleSourceFifoOrderObjectSerializer.java
@@ -1,0 +1,95 @@
+package rx.broadcast.integration.pp;
+
+import org.junit.Test;
+import rx.Observable;
+import rx.broadcast.Broadcast;
+import rx.broadcast.ObjectSerializer;
+import rx.broadcast.SingleSourceFifoOrder;
+import rx.broadcast.UdpBroadcast;
+import rx.observers.TestSubscriber;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+
+@SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:LineLength", "checkstyle:AvoidInlineConditionals"})
+public class PingPongUdpSingleSourceFifoOrderObjectSerializer {
+    private static final int MESSAGE_COUNT = 100;
+
+    private static final long TIMEOUT = 30;
+
+    /**
+     * Receive a PING and respond with a PONG.
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    @Test
+    public final void recv() throws SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new ObjectSerializer<>(), new SingleSourceFifoOrder<>());
+        final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
+
+        broadcast.valuesOfType(Ping.class)
+            .doOnNext(System.out::println)
+            .concatMap(ping ->
+                broadcast.send(new Pong(ping.value))
+                    // Once we've sent the response, we can emit the PING value to the subscriber.
+                    // The cast here is a hack to allow us to concatenate a PING onto the stream.
+                    // Where this is an `Observable<Void>` we know we won't get anything that needs to be casted.
+                    .cast(Ping.class)
+                    .concatWith(Observable.just(ping))
+                    .doOnCompleted(() -> System.out.println("Sent PONG")))
+            .take(MESSAGE_COUNT)
+            .subscribe(subscriber);
+
+        subscriber.awaitTerminalEventAndUnsubscribeOnTimeout(TIMEOUT, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(MESSAGE_COUNT);
+    }
+
+    /**
+     * Send a set PING messages to the receiver, expecting PONG messages in response.
+     * @param args the command line arguments passed to the program
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new ObjectSerializer<>(), new SingleSourceFifoOrder<>());
+
+        Observable.range(1, MESSAGE_COUNT)
+            .map(Ping::new)
+            .doOnNext(System.out::println)
+            .concatMap(value ->
+                broadcast.send(value)
+                    .doOnCompleted(() -> System.out.printf("Sent %s%n", value))
+                    .cast(Pong.class)
+                    .concatWith(broadcast.valuesOfType(Pong.class).first()))
+            .timeout(TIMEOUT, TimeUnit.SECONDS)
+            .toBlocking()
+            .subscribe(pong ->
+                System.out.printf("Received %s%n", pong));
+    }
+}

--- a/src/test/java/rx/broadcast/integration/pp/PingPongUdpSingleSourceFifoOrderProtobufSerializer.java
+++ b/src/test/java/rx/broadcast/integration/pp/PingPongUdpSingleSourceFifoOrderProtobufSerializer.java
@@ -1,0 +1,99 @@
+package rx.broadcast.integration.pp;
+
+import org.junit.Test;
+import rx.Observable;
+import rx.broadcast.Broadcast;
+import rx.broadcast.ObjectSerializer;
+import rx.broadcast.Serializer;
+import rx.broadcast.SingleSourceFifoOrder;
+import rx.broadcast.SingleSourceFifoOrderProtobufSerializer;
+import rx.broadcast.UdpBroadcast;
+import rx.observers.TestSubscriber;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+
+@SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:LineLength", "checkstyle:AvoidInlineConditionals"})
+public class PingPongUdpSingleSourceFifoOrderProtobufSerializer {
+    private static final int MESSAGE_COUNT = 100;
+
+    private static final long TIMEOUT = 30;
+
+    /**
+     * Receive a PING and respond with a PONG.
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    @Test
+    public final void recv() throws SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Serializer<Object> s = new ObjectSerializer<>();
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new SingleSourceFifoOrderProtobufSerializer<>(s), new SingleSourceFifoOrder<>());
+        final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
+
+        broadcast.valuesOfType(Ping.class)
+            .doOnNext(System.out::println)
+            .concatMap(ping ->
+                broadcast.send(new Pong(ping.value))
+                    // Once we've sent the response, we can emit the PING value to the subscriber.
+                    // The cast here is a hack to allow us to concatenate a PING onto the stream.
+                    // Where this is an `Observable<Void>` we know we won't get anything that needs to be casted.
+                    .cast(Ping.class)
+                    .concatWith(Observable.just(ping))
+                    .doOnCompleted(() -> System.out.println("Sent PONG")))
+            .take(MESSAGE_COUNT)
+            .subscribe(subscriber);
+
+        subscriber.awaitTerminalEventAndUnsubscribeOnTimeout(TIMEOUT, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(MESSAGE_COUNT);
+    }
+
+    /**
+     * Send a set PING messages to the receiver, expecting PONG messages in response.
+     * @param args the command line arguments passed to the program
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Serializer<Object> s = new ObjectSerializer<>();
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new SingleSourceFifoOrderProtobufSerializer<>(s), new SingleSourceFifoOrder<>());
+
+        Observable.range(1, MESSAGE_COUNT)
+            .map(Ping::new)
+            .doOnNext(System.out::println)
+            .concatMap(value ->
+                broadcast.send(value)
+                    .doOnCompleted(() -> System.out.printf("Sent %s%n", value))
+                    .cast(Pong.class)
+                    .concatWith(broadcast.valuesOfType(Pong.class).first()))
+            .timeout(TIMEOUT, TimeUnit.SECONDS)
+            .toBlocking()
+            .subscribe(pong ->
+                System.out.printf("Received %s%n", pong));
+    }
+}

--- a/src/test/java/rx/broadcast/integration/pp/Pong.java
+++ b/src/test/java/rx/broadcast/integration/pp/Pong.java
@@ -6,7 +6,7 @@ public final class Pong {
     @SuppressWarnings("WeakerAccess")
     public int value;
 
-    public Pong(final int value) {
+    Pong(final int value) {
         this.value = value;
     }
 

--- a/src/test/java/rx/broadcast/integration/pp/Pong.java
+++ b/src/test/java/rx/broadcast/integration/pp/Pong.java
@@ -1,8 +1,11 @@
 package rx.broadcast.integration.pp;
 
+import java.io.Serializable;
 import java.util.Objects;
 
-public final class Pong {
+public final class Pong implements Serializable {
+    private static final long serialVersionUID = 114L;
+
     @SuppressWarnings("WeakerAccess")
     public int value;
 


### PR DESCRIPTION
Closes #2

This PR "adapterizes" the serialization for objects in transits (messages on the wire). Previously messages and their wrapper types were serialized using [Kryo](https://github.com/EsotericSoftware/kryo)—this PR adds serializers using Java's native object I/O and Protocol Buffers.

Kryo works wonders for ~~Java-to-Java~~ JVM-to-JVM communication, but it does not work in cases where multiple platforms and/or runtimes and/or languages are serializing messages—something like JSON or [MessagePack](http://msgpack.org) or [Protocol Buffers](https://developers.google.com/protocol-buffers/) would be more ideal.

### What's the catch?

The serialization of internal types (i.e. the wrapper types for messages) is darn near impossible for serialization methods that don't use reflection. As such, alternative serialization methods will either need to have predefined ways to serialize the wrapper types (e.g. the schemas for Protocol Buffers included in this PR) or a use reflection to in serialize types.