### PR TITLE
Add ObjectSerializer using Java's native object I/O

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,13 @@ script:
     - scripts/test rx.broadcast.integration.BasicOrderUdpBroadcastTest
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpBasicOrder
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpBasicOrderKryoSerializer
+    - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpBasicOrderObjectSerializer
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpSingleSourceFifoOrder
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpSingleSourceFifoOrderKryoSerializer
+    - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpSingleSourceFifoOrderObjectSerializer
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrder
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrderKryoSerializer
+    - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrderObjectSerializer
 deploy:
     provider: script
     script: scripts/deploy

--- a/src/main/java/rx/broadcast/ObjectSerializer.java
+++ b/src/main/java/rx/broadcast/ObjectSerializer.java
@@ -1,0 +1,33 @@
+package rx.broadcast;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+public final class ObjectSerializer<T> implements Serializer<T> {
+    @Override
+    @SuppressWarnings("unchecked")
+    public final T decode(final byte[] data) {
+        try {
+            final ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(data));
+            return (T) ois.readObject();
+        } catch (final ClassNotFoundException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public final byte[] encode(final T data) {
+        try {
+            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            final ObjectOutputStream oos = new ObjectOutputStream(baos);
+            oos.writeObject(data);
+            oos.flush();
+            return baos.toByteArray();
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/rx/broadcast/Timestamped.java
+++ b/src/main/java/rx/broadcast/Timestamped.java
@@ -1,8 +1,11 @@
 package rx.broadcast;
 
+import java.io.Serializable;
 import java.util.Objects;
 
-final class Timestamped<T> implements Comparable<Timestamped<T>> {
+final class Timestamped<T> implements Comparable<Timestamped<T>>, Serializable {
+    private static final long serialVersionUID = 114L;
+
     @SuppressWarnings("WeakerAccess")
     public long timestamp;
 

--- a/src/main/java/rx/broadcast/VectorTimestamp.java
+++ b/src/main/java/rx/broadcast/VectorTimestamp.java
@@ -1,9 +1,12 @@
 package rx.broadcast;
 
+import java.io.Serializable;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-final class VectorTimestamp {
+final class VectorTimestamp implements Serializable {
+    private static final long serialVersionUID = 114L;
+
     private long[] ids;
 
     private long[] timestamps;

--- a/src/main/java/rx/broadcast/VectorTimestamped.java
+++ b/src/main/java/rx/broadcast/VectorTimestamped.java
@@ -1,11 +1,15 @@
 package rx.broadcast;
 
+import java.io.Serializable;
+
 /**
  * Represents a value of type {@code T} that has been timestamped with a {@code VectorTimestamp}.
  * @param <T> the type of the timestamped value.
  */
 @SuppressWarnings("WeakerAccess")
-final class VectorTimestamped<T> {
+final class VectorTimestamped<T> implements Serializable {
+    private static final long serialVersionUID = 114L;
+
     public VectorTimestamp timestamp;
 
     public T value;

--- a/src/test/java/rx/broadcast/integration/pp/Ping.java
+++ b/src/test/java/rx/broadcast/integration/pp/Ping.java
@@ -1,8 +1,11 @@
 package rx.broadcast.integration.pp;
 
+import java.io.Serializable;
 import java.util.Objects;
 
-public final class Ping {
+public final class Ping implements Serializable {
+    private static final long serialVersionUID = 114L;
+
     @SuppressWarnings("WeakerAccess")
     public int value;
 

--- a/src/test/java/rx/broadcast/integration/pp/PingPongUdpBasicOrderObjectSerializer.java
+++ b/src/test/java/rx/broadcast/integration/pp/PingPongUdpBasicOrderObjectSerializer.java
@@ -1,0 +1,81 @@
+package rx.broadcast.integration.pp;
+
+import org.junit.Test;
+import rx.Observable;
+import rx.broadcast.BasicOrder;
+import rx.broadcast.Broadcast;
+import rx.broadcast.ObjectSerializer;
+import rx.broadcast.UdpBroadcast;
+import rx.observers.TestSubscriber;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+
+public class PingPongUdpBasicOrderObjectSerializer {
+    private static final int MESSAGE_COUNT = 100;
+
+    private static final long TIMEOUT = 30;
+
+    /**
+     * Receive a PING and respond with a PONG.
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    @Test
+    public final void recv() throws SocketException, UnknownHostException {
+        final int port = Integer.valueOf(System.getProperty("port"));
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, port, new ObjectSerializer<>(), new BasicOrder<>());
+
+        final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
+
+        broadcast.valuesOfType(Ping.class)
+            .doOnNext(System.out::println)
+            .concatMap(ping ->
+                broadcast.send(new Pong(ping.value))
+                    // Once we've sent the response, we can emit the PING value to the subscriber.
+                    // The cast here is a hack to allow us to concatenate a PING onto the stream.
+                    // Where this is an `Observable<Void>` we know we won't get anything that needs to be casted.
+                    .cast(Ping.class)
+                    .concatWith(Observable.just(ping))
+                    .doOnCompleted(() -> System.out.println("Sent PONG")))
+            .take(MESSAGE_COUNT)
+            .subscribe(subscriber);
+
+        subscriber.awaitTerminalEventAndUnsubscribeOnTimeout(TIMEOUT, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(MESSAGE_COUNT);
+    }
+
+    /**
+     * Send a set PING messages to the receiver, expecting PONG messages in response.
+     * @param args the command line arguments passed to the program
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
+        final int port = Integer.valueOf(System.getProperty("port"));
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, port, new ObjectSerializer<>(), new BasicOrder<>());
+
+        Observable.range(1, MESSAGE_COUNT)
+            .map(Ping::new)
+            .doOnNext(System.out::println)
+            .concatMap(value ->
+                broadcast.send(value)
+                    .doOnCompleted(() -> System.out.printf("Sent %s%n", value))
+                    .cast(Pong.class)
+                    .concatWith(broadcast.valuesOfType(Pong.class).first()))
+            .timeout(TIMEOUT, TimeUnit.SECONDS)
+            .toBlocking()
+            .subscribe(pong ->
+                System.out.printf("Received %s%n", pong));
+    }
+}

--- a/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrderObjectSerializer.java
+++ b/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrderObjectSerializer.java
@@ -1,0 +1,95 @@
+package rx.broadcast.integration.pp;
+
+import org.junit.Test;
+import rx.Observable;
+import rx.broadcast.Broadcast;
+import rx.broadcast.CausalOrder;
+import rx.broadcast.ObjectSerializer;
+import rx.broadcast.UdpBroadcast;
+import rx.observers.TestSubscriber;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+
+@SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:AvoidInlineConditionals"})
+public class PingPongUdpCausalOrderObjectSerializer {
+    private static final int MESSAGE_COUNT = 100;
+
+    private static final long TIMEOUT = 30;
+
+    /**
+     * Receive a PING and respond with a PONG.
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    @Test
+    public final void recv() throws SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new ObjectSerializer<>(), new CausalOrder<>());
+        final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
+
+        broadcast.valuesOfType(Ping.class)
+            .doOnNext(System.out::println)
+            .concatMap(ping ->
+                broadcast.send(new Pong(ping.value))
+                    // Once we've sent the response, we can emit the PING value to the subscriber.
+                    // The cast here is a hack to allow us to concatenate a PING onto the stream.
+                    // Where this is an `Observable<Void>` we know we won't get anything that needs to be casted.
+                    .cast(Ping.class)
+                    .concatWith(Observable.just(ping))
+                    .doOnCompleted(() -> System.out.println("Sent PONG")))
+            .take(MESSAGE_COUNT)
+            .subscribe(subscriber);
+
+        subscriber.awaitTerminalEventAndUnsubscribeOnTimeout(TIMEOUT, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(MESSAGE_COUNT);
+    }
+
+    /**
+     * Send a set PING messages to the receiver, expecting PONG messages in response.
+     * @param args the command line arguments passed to the program
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new ObjectSerializer<>(), new CausalOrder<>());
+
+        Observable.range(1, MESSAGE_COUNT)
+            .map(Ping::new)
+            .doOnNext(System.out::println)
+            .concatMap(value ->
+                broadcast.send(value)
+                    .doOnCompleted(() -> System.out.printf("Sent %s%n", value))
+                    .cast(Pong.class)
+                    .concatWith(broadcast.valuesOfType(Pong.class).first()))
+            .timeout(TIMEOUT, TimeUnit.SECONDS)
+            .toBlocking()
+            .subscribe(pong ->
+                System.out.printf("Received %s%n", pong));
+    }
+}

--- a/src/test/java/rx/broadcast/integration/pp/PingPongUdpSingleSourceFifoOrderObjectSerializer.java
+++ b/src/test/java/rx/broadcast/integration/pp/PingPongUdpSingleSourceFifoOrderObjectSerializer.java
@@ -1,0 +1,95 @@
+package rx.broadcast.integration.pp;
+
+import org.junit.Test;
+import rx.Observable;
+import rx.broadcast.Broadcast;
+import rx.broadcast.ObjectSerializer;
+import rx.broadcast.SingleSourceFifoOrder;
+import rx.broadcast.UdpBroadcast;
+import rx.observers.TestSubscriber;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+
+@SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:LineLength", "checkstyle:AvoidInlineConditionals"})
+public class PingPongUdpSingleSourceFifoOrderObjectSerializer {
+    private static final int MESSAGE_COUNT = 100;
+
+    private static final long TIMEOUT = 30;
+
+    /**
+     * Receive a PING and respond with a PONG.
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    @Test
+    public final void recv() throws SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new ObjectSerializer<>(), new SingleSourceFifoOrder<>());
+        final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
+
+        broadcast.valuesOfType(Ping.class)
+            .doOnNext(System.out::println)
+            .concatMap(ping ->
+                broadcast.send(new Pong(ping.value))
+                    // Once we've sent the response, we can emit the PING value to the subscriber.
+                    // The cast here is a hack to allow us to concatenate a PING onto the stream.
+                    // Where this is an `Observable<Void>` we know we won't get anything that needs to be casted.
+                    .cast(Ping.class)
+                    .concatWith(Observable.just(ping))
+                    .doOnCompleted(() -> System.out.println("Sent PONG")))
+            .take(MESSAGE_COUNT)
+            .subscribe(subscriber);
+
+        subscriber.awaitTerminalEventAndUnsubscribeOnTimeout(TIMEOUT, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(MESSAGE_COUNT);
+    }
+
+    /**
+     * Send a set PING messages to the receiver, expecting PONG messages in response.
+     * @param args the command line arguments passed to the program
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new ObjectSerializer<>(), new SingleSourceFifoOrder<>());
+
+        Observable.range(1, MESSAGE_COUNT)
+            .map(Ping::new)
+            .doOnNext(System.out::println)
+            .concatMap(value ->
+                broadcast.send(value)
+                    .doOnCompleted(() -> System.out.printf("Sent %s%n", value))
+                    .cast(Pong.class)
+                    .concatWith(broadcast.valuesOfType(Pong.class).first()))
+            .timeout(TIMEOUT, TimeUnit.SECONDS)
+            .toBlocking()
+            .subscribe(pong ->
+                System.out.printf("Received %s%n", pong));
+    }
+}

--- a/src/test/java/rx/broadcast/integration/pp/Pong.java
+++ b/src/test/java/rx/broadcast/integration/pp/Pong.java
@@ -1,8 +1,11 @@
 package rx.broadcast.integration.pp;
 
+import java.io.Serializable;
 import java.util.Objects;
 
-public final class Pong {
+public final class Pong implements Serializable {
+    private static final long serialVersionUID = 114L;
+
     @SuppressWarnings("WeakerAccess")
     public int value;
 


### PR DESCRIPTION
This PR adds a new `Serializer` implementation using Java's native object I/O: `ObjectSerializer`