### PR TITLE
Add serializers for SSF and causal order using Protocol Buffers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpSingleSourceFifoOrder
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpSingleSourceFifoOrderKryoSerializer
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpSingleSourceFifoOrderObjectSerializer
+    - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpSingleSourceFifoOrderProtobufSerializer
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrder
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrderKryoSerializer
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrderObjectSerializer

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ script:
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrder
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrderKryoSerializer
     - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrderObjectSerializer
+    - scripts/test-table-tennis rx.broadcast.integration.pp.PingPongUdpCausalOrderProtobufSerializer
 deploy:
     provider: script
     script: scripts/deploy

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ repositories {
 
 dependencies {
     compile 'com.esotericsoftware:kryo:3.0.3'
+    compile 'com.google.protobuf:protobuf-java:3.3.0'
     compile 'io.reactivex:rxjava:1.3.0'
     testCompile 'junit:junit:4.12'
 }

--- a/src/main/java/rx/broadcast/CausalOrderProtobufSerializer.java
+++ b/src/main/java/rx/broadcast/CausalOrderProtobufSerializer.java
@@ -1,0 +1,125 @@
+package rx.broadcast;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldOptions;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Parser;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class CausalOrderProtobufSerializer<T> implements Serializer<VectorTimestamped<T>> {
+    private static final String MESSAGE_NAME = "VectorTimestamped";
+
+    private static final String IDS_FIELD_NAME = "ids";
+
+    private static final String TIMESTAMPS_FIELD_NAME = "timestamps";
+
+    private static final String VALUE_FIELD_NAME = "value";
+
+    private static final int IDS_FIELD_NUMBER = 1;
+
+    private static final int TIMESTAMPS_FIELD_NUMBER = 2;
+
+    private static final int VALUE_FIELD_NUMBER = 3;
+
+    private final FieldDescriptor ids;
+
+    private final FieldDescriptor timestamps;
+
+    private final FieldDescriptor value;
+
+    private final DynamicMessage.Builder messageBuilder;
+
+    private final Parser<DynamicMessage> messageParser;
+
+    private final Serializer<T> objectSerializer;
+
+    public CausalOrderProtobufSerializer(final Serializer<T> objectSerializer) {
+        this.objectSerializer = objectSerializer;
+        try {
+            final FileDescriptorProto timestampedMessageFile = FileDescriptorProto.newBuilder()
+                .addMessageType(
+                    DescriptorProto.newBuilder()
+                        .setName(MESSAGE_NAME)
+                        .addField(
+                            FieldDescriptorProto.newBuilder()
+                                .setLabel(FieldDescriptorProto.Label.LABEL_REPEATED)
+                                .setName(IDS_FIELD_NAME)
+                                .setNumber(IDS_FIELD_NUMBER)
+                                .setOptions(FieldOptions.newBuilder()
+                                    .setPacked(true))
+                                .setType(FieldDescriptorProto.Type.TYPE_UINT64))
+                        .addField(
+                            FieldDescriptorProto.newBuilder()
+                                .setLabel(FieldDescriptorProto.Label.LABEL_REPEATED)
+                                .setName(TIMESTAMPS_FIELD_NAME)
+                                .setNumber(TIMESTAMPS_FIELD_NUMBER)
+                                .setOptions(FieldOptions.newBuilder()
+                                    .setPacked(true))
+                                .setType(FieldDescriptorProto.Type.TYPE_UINT64))
+                        .addField(
+                            FieldDescriptorProto.newBuilder()
+                                .setName(VALUE_FIELD_NAME)
+                                .setNumber(VALUE_FIELD_NUMBER)
+                                .setType(FieldDescriptorProto.Type.TYPE_BYTES)))
+                .build();
+            final Descriptor message = FileDescriptor
+                .buildFrom(timestampedMessageFile, new FileDescriptor[0])
+                .findMessageTypeByName(MESSAGE_NAME);
+            this.ids = message.findFieldByName(IDS_FIELD_NAME);
+            this.timestamps = message.findFieldByName(TIMESTAMPS_FIELD_NAME);
+            this.value = message.findFieldByName(VALUE_FIELD_NAME);
+            this.messageBuilder = DynamicMessage.newBuilder(message);
+            this.messageParser = messageBuilder.buildPartial().getParserForType();
+        } catch (final DescriptorValidationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public final VectorTimestamped<T> decode(final byte[] data) {
+        try {
+            final DynamicMessage message = messageParser.parseFrom(data);
+            final byte[] bytes = ((ByteString) message.getField(this.value)).toByteArray();
+            final T value = objectSerializer.decode(bytes);
+            final int idsCount = message.getRepeatedFieldCount(this.ids);
+            final int timestampsCount = message.getRepeatedFieldCount(this.timestamps);
+            final long[] ids = new long[idsCount];
+            final long[] timestamps = new long[timestampsCount];
+
+            for (int i = 0; i < idsCount; i++) {
+                ids[i] = (long) message.getRepeatedField(this.ids, i);
+            }
+            for (int i = 0; i < timestampsCount; i++) {
+                timestamps[i] = (long) message.getRepeatedField(this.timestamps, i);
+            }
+
+            return new VectorTimestamped<>(value, new VectorTimestamp(ids, timestamps));
+        } catch (final InvalidProtocolBufferException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public final byte[] encode(final VectorTimestamped<T> data) {
+        final DynamicMessage.Builder builder = messageBuilder
+            .setField(this.value, objectSerializer.encode(data.value));
+
+        final AtomicInteger i = new AtomicInteger(0);
+        data.timestamp.stream().forEachOrdered(entry -> {
+            builder.setRepeatedField(this.ids, i.get(), entry.id);
+            builder.setRepeatedField(this.timestamps, i.get(), entry.timestamp);
+            i.incrementAndGet();
+        });
+
+        return builder.build().toByteArray();
+    }
+}

--- a/src/main/java/rx/broadcast/SingleSourceFifoOrderProtobufSerializer.java
+++ b/src/main/java/rx/broadcast/SingleSourceFifoOrderProtobufSerializer.java
@@ -1,0 +1,87 @@
+package rx.broadcast;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.DescriptorValidationException;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Parser;
+
+public final class SingleSourceFifoOrderProtobufSerializer<T> implements Serializer<Timestamped<T>> {
+    private static final String MESSAGE_NAME = "Timestamped";
+
+    private static final String TIMESTAMP_FIELD_NAME = "timestamp";
+
+    private static final String VALUE_FIELD_NAME = "value";
+
+    private static final int TIMESTAMP_FIELD_NUMBER = 1;
+
+    private static final int VALUE_FIELD_NUMBER = 2;
+
+    private final FieldDescriptor timestampedMessageField;
+
+    private final FieldDescriptor valueMessageField;
+
+    private final DynamicMessage.Builder messageBuilder;
+
+    private final Parser<DynamicMessage> messageParser;
+
+    private final Serializer<T> objectSerializer;
+
+    public SingleSourceFifoOrderProtobufSerializer(final Serializer<T> objectSerializer) {
+        this.objectSerializer = objectSerializer;
+        try {
+            final FileDescriptorProto timestampedMessageFile = FileDescriptorProto.newBuilder()
+                .addMessageType(
+                    DescriptorProto.newBuilder()
+                        .setName(MESSAGE_NAME)
+                        .addField(
+                            FieldDescriptorProto.newBuilder()
+                                .setName(TIMESTAMP_FIELD_NAME)
+                                .setNumber(TIMESTAMP_FIELD_NUMBER)
+                                .setType(FieldDescriptorProto.Type.TYPE_INT64))
+                        .addField(
+                            FieldDescriptorProto.newBuilder()
+                                .setName(VALUE_FIELD_NAME)
+                                .setNumber(VALUE_FIELD_NUMBER)
+                                .setType(FieldDescriptorProto.Type.TYPE_BYTES)))
+                .build();
+            final Descriptor message = FileDescriptor
+                .buildFrom(timestampedMessageFile, new FileDescriptor[0])
+                .findMessageTypeByName(MESSAGE_NAME);
+            this.timestampedMessageField = message.findFieldByName(TIMESTAMP_FIELD_NAME);
+            this.valueMessageField = message.findFieldByName(VALUE_FIELD_NAME);
+            this.messageBuilder = DynamicMessage.newBuilder(message);
+            this.messageParser = messageBuilder.buildPartial().getParserForType();
+        } catch (final DescriptorValidationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public final Timestamped<T> decode(final byte[] data) {
+        try {
+            final DynamicMessage message = messageParser.parseFrom(data);
+            final long timestamp = (long) message.getField(timestampedMessageField);
+            final byte[] bytes = ((ByteString) message.getField(valueMessageField)).toByteArray();
+            final T value = objectSerializer.decode(bytes);
+            return new Timestamped<>(timestamp, value);
+        } catch (final InvalidProtocolBufferException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public final byte[] encode(final Timestamped<T> data) {
+        return messageBuilder
+            .setField(timestampedMessageField, data.timestamp)
+            .setField(valueMessageField, objectSerializer.encode(data.value))
+            .build()
+            .toByteArray();
+    }
+}

--- a/src/main/proto/rx/broadcast/Timestamped.proto
+++ b/src/main/proto/rx/broadcast/Timestamped.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+
+option java_package = "rx.broadcast";
+option java_outer_classname = "ProtobufTimestamped";
+
+message Timestamped {
+    required uint64 timestamp = 1;
+    required bytes value = 2;
+}

--- a/src/main/proto/rx/broadcast/VectorTimestamped.proto
+++ b/src/main/proto/rx/broadcast/VectorTimestamped.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+
+option java_package = "rx.broadcast";
+option java_outer_classname = "ProtobufVectorTimestamped";
+
+message VectorTimestamped {
+    repeated uint64 ids = 1 [packed=true];
+    repeated uint64 timestamps = 2 [packed=true];
+    required bytes value = 3;
+}

--- a/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrderProtobufSerializer.java
+++ b/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrderProtobufSerializer.java
@@ -1,0 +1,99 @@
+package rx.broadcast.integration.pp;
+
+import org.junit.Test;
+import rx.Observable;
+import rx.broadcast.Broadcast;
+import rx.broadcast.CausalOrder;
+import rx.broadcast.CausalOrderProtobufSerializer;
+import rx.broadcast.ObjectSerializer;
+import rx.broadcast.Serializer;
+import rx.broadcast.UdpBroadcast;
+import rx.observers.TestSubscriber;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+
+@SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:AvoidInlineConditionals"})
+public class PingPongUdpCausalOrderProtobufSerializer {
+    private static final int MESSAGE_COUNT = 100;
+
+    private static final long TIMEOUT = 30;
+
+    /**
+     * Receive a PING and respond with a PONG.
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    @Test
+    public final void recv() throws SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Serializer<Object> s = new ObjectSerializer<>();
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new CausalOrderProtobufSerializer<>(s), new CausalOrder<>());
+        final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
+
+        broadcast.valuesOfType(Ping.class)
+            .doOnNext(System.out::println)
+            .concatMap(ping ->
+                broadcast.send(new Pong(ping.value))
+                    // Once we've sent the response, we can emit the PING value to the subscriber.
+                    // The cast here is a hack to allow us to concatenate a PING onto the stream.
+                    // Where this is an `Observable<Void>` we know we won't get anything that needs to be casted.
+                    .cast(Ping.class)
+                    .concatWith(Observable.just(ping))
+                    .doOnCompleted(() -> System.out.println("Sent PONG")))
+            .take(MESSAGE_COUNT)
+            .subscribe(subscriber);
+
+        subscriber.awaitTerminalEventAndUnsubscribeOnTimeout(TIMEOUT, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(MESSAGE_COUNT);
+    }
+
+    /**
+     * Send a set PING messages to the receiver, expecting PONG messages in response.
+     * @param args the command line arguments passed to the program
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Serializer<Object> s = new ObjectSerializer<>();
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new CausalOrderProtobufSerializer<>(s), new CausalOrder<>());
+
+        Observable.range(1, MESSAGE_COUNT)
+            .map(Ping::new)
+            .doOnNext(System.out::println)
+            .concatMap(value ->
+                broadcast.send(value)
+                    .doOnCompleted(() -> System.out.printf("Sent %s%n", value))
+                    .cast(Pong.class)
+                    .concatWith(broadcast.valuesOfType(Pong.class).first()))
+            .timeout(TIMEOUT, TimeUnit.SECONDS)
+            .toBlocking()
+            .subscribe(pong ->
+                System.out.printf("Received %s%n", pong));
+    }
+}

--- a/src/test/java/rx/broadcast/integration/pp/PingPongUdpSingleSourceFifoOrderProtobufSerializer.java
+++ b/src/test/java/rx/broadcast/integration/pp/PingPongUdpSingleSourceFifoOrderProtobufSerializer.java
@@ -1,0 +1,99 @@
+package rx.broadcast.integration.pp;
+
+import org.junit.Test;
+import rx.Observable;
+import rx.broadcast.Broadcast;
+import rx.broadcast.ObjectSerializer;
+import rx.broadcast.Serializer;
+import rx.broadcast.SingleSourceFifoOrder;
+import rx.broadcast.SingleSourceFifoOrderProtobufSerializer;
+import rx.broadcast.UdpBroadcast;
+import rx.observers.TestSubscriber;
+
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+
+@SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:LineLength", "checkstyle:AvoidInlineConditionals"})
+public class PingPongUdpSingleSourceFifoOrderProtobufSerializer {
+    private static final int MESSAGE_COUNT = 100;
+
+    private static final long TIMEOUT = 30;
+
+    /**
+     * Receive a PING and respond with a PONG.
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    @Test
+    public final void recv() throws SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Serializer<Object> s = new ObjectSerializer<>();
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new SingleSourceFifoOrderProtobufSerializer<>(s), new SingleSourceFifoOrder<>());
+        final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
+
+        broadcast.valuesOfType(Ping.class)
+            .doOnNext(System.out::println)
+            .concatMap(ping ->
+                broadcast.send(new Pong(ping.value))
+                    // Once we've sent the response, we can emit the PING value to the subscriber.
+                    // The cast here is a hack to allow us to concatenate a PING onto the stream.
+                    // Where this is an `Observable<Void>` we know we won't get anything that needs to be casted.
+                    .cast(Ping.class)
+                    .concatWith(Observable.just(ping))
+                    .doOnCompleted(() -> System.out.println("Sent PONG")))
+            .take(MESSAGE_COUNT)
+            .subscribe(subscriber);
+
+        subscriber.awaitTerminalEventAndUnsubscribeOnTimeout(TIMEOUT, TimeUnit.SECONDS);
+        subscriber.assertNoErrors();
+        subscriber.assertValueCount(MESSAGE_COUNT);
+    }
+
+    /**
+     * Send a set PING messages to the receiver, expecting PONG messages in response.
+     * @param args the command line arguments passed to the program
+     * @throws SocketException if the socket could not be opened, or the socket could not bind to the given port.
+     * @throws UnknownHostException if no IP address for the host machine could be found.
+     */
+    public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
+        final int port = System.getProperty("port") != null
+            ? Integer.valueOf(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.valueOf(System.getProperty("destinationPort"))
+            : 12345;
+        final DatagramSocket socket = new DatagramSocket(port);
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getByName("localhost");
+        final Serializer<Object> s = new ObjectSerializer<>();
+        final Broadcast broadcast = new UdpBroadcast<>(
+            socket, destination, destinationPort, new SingleSourceFifoOrderProtobufSerializer<>(s), new SingleSourceFifoOrder<>());
+
+        Observable.range(1, MESSAGE_COUNT)
+            .map(Ping::new)
+            .doOnNext(System.out::println)
+            .concatMap(value ->
+                broadcast.send(value)
+                    .doOnCompleted(() -> System.out.printf("Sent %s%n", value))
+                    .cast(Pong.class)
+                    .concatWith(broadcast.valuesOfType(Pong.class).first()))
+            .timeout(TIMEOUT, TimeUnit.SECONDS)
+            .toBlocking()
+            .subscribe(pong ->
+                System.out.printf("Received %s%n", pong));
+    }
+}


### PR DESCRIPTION
Refs: [Protocol Buffers](https://developers.google.com/protocol-buffers/)

This PR adds serializers for SSF and causal order using Google's Protocol Buffers. I've included the `.proto` files themselves in the project should they be of use to API consumers.