### PR TITLE
IPv6 support

### DIFF
--- a/scripts/test-ipv6
+++ b/scripts/test-ipv6
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+readonly DIR=$(cd "${BASH_SOURCE[0]%/*}" && pwd)
+
+docker_run() {
+    docker run --net=host --detach rxb '-Ddestination=ff02::1' '-Dport=8888' "$@"
+}
+
+class=$1
+network_command=${2:-:}
+
+containers=()
+for _ in {1..5}
+do
+    container=$(docker_run 'org.junit.runner.JUnitCore' "$class")
+    DOCKER_IFACE=$("$DIR/veth" "$container") bash -xc "shopt -s extglob; $network_command"
+    containers+=($container)
+done
+
+containers+=($(docker_run "$class"))
+
+if ! docker wait "${containers[@]}" | awk '/1/ { exit 1 }'
+then
+    set -x
+    for container in "${containers[@]}"
+    do
+        docker logs "$container"
+    done
+    exit 1
+fi

--- a/scripts/test-table-tennis-ipv6
+++ b/scripts/test-table-tennis-ipv6
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+readonly DIR=$(cd "${BASH_SOURCE[0]%/*}" && pwd)
+
+docker_run() {
+    docker run --net=host --detach rxb '-Dport=8888' '-Ddestination=ff02::1' '-DdestinationPort=8888' "$@"
+}
+
+class=$1
+
+containers=()
+container=$(docker_run 'org.junit.runner.JUnitCore' "$class")
+containers+=($container)
+
+containers+=($(docker_run "$class"))
+
+if ! docker wait "${containers[@]}" | awk '/1/ { exit 1 }'
+then
+    set -x
+    for container in "${containers[@]}"
+    do
+        docker logs "$container"
+    done
+    exit 1
+fi

--- a/src/main/java/rx/broadcast/BasicOrder.java
+++ b/src/main/java/rx/broadcast/BasicOrder.java
@@ -20,7 +20,7 @@ public final class BasicOrder<T> implements BroadcastOrder<T, T> {
      * {@inheritDoc}
      */
     @Override
-    public void receive(final long sender, final Consumer<T> consumer, final T message) {
+    public void receive(final Sender sender, final Consumer<T> consumer, final T message) {
         consumer.accept(message);
     }
 }

--- a/src/main/java/rx/broadcast/BroadcastOrder.java
+++ b/src/main/java/rx/broadcast/BroadcastOrder.java
@@ -29,5 +29,5 @@ public interface BroadcastOrder<M, T> {
      * @param consumer the intended consumer of the message
      * @param message the message sent by the sender
      */
-    void receive(long sender, Consumer<T> consumer, M message);
+    void receive(Sender sender, Consumer<T> consumer, M message);
 }

--- a/src/main/java/rx/broadcast/CausalOrderProtobufSerializer.java
+++ b/src/main/java/rx/broadcast/CausalOrderProtobufSerializer.java
@@ -54,9 +54,7 @@ public class CausalOrderProtobufSerializer<T> implements Serializer<VectorTimest
                                 .setLabel(FieldDescriptorProto.Label.LABEL_REPEATED)
                                 .setName(IDS_FIELD_NAME)
                                 .setNumber(IDS_FIELD_NUMBER)
-                                .setOptions(FieldOptions.newBuilder()
-                                    .setPacked(true))
-                                .setType(FieldDescriptorProto.Type.TYPE_UINT64))
+                                .setType(FieldDescriptorProto.Type.TYPE_BYTES))
                         .addField(
                             FieldDescriptorProto.newBuilder()
                                 .setLabel(FieldDescriptorProto.Label.LABEL_REPEATED)
@@ -92,11 +90,11 @@ public class CausalOrderProtobufSerializer<T> implements Serializer<VectorTimest
             final T value = objectSerializer.decode(bytes);
             final int idsCount = message.getRepeatedFieldCount(this.ids);
             final int timestampsCount = message.getRepeatedFieldCount(this.timestamps);
-            final long[] ids = new long[idsCount];
+            final Sender[] ids = new Sender[idsCount];
             final long[] timestamps = new long[timestampsCount];
 
             for (int i = 0; i < idsCount; i++) {
-                ids[i] = (long) message.getRepeatedField(this.ids, i);
+                ids[i] = new Sender(((ByteString) message.getRepeatedField(this.ids, i)).toByteArray());
             }
             for (int i = 0; i < timestampsCount; i++) {
                 timestamps[i] = (long) message.getRepeatedField(this.timestamps, i);

--- a/src/main/java/rx/broadcast/Sender.java
+++ b/src/main/java/rx/broadcast/Sender.java
@@ -1,0 +1,32 @@
+package rx.broadcast;
+
+import java.nio.ByteBuffer;
+
+public final class Sender implements Comparable<Sender> {
+    private final ByteBuffer bytes;
+
+    Sender(final byte[] bytes) {
+        this.bytes = ByteBuffer.wrap(bytes);
+    }
+
+    @Override
+    public final boolean equals(final Object o) {
+        return this == o || !(o == null || getClass() != o.getClass()) && bytes.equals(((Sender) o).bytes);
+
+    }
+
+    @Override
+    public final int hashCode() {
+        return bytes.hashCode();
+    }
+
+    @Override
+    public int compareTo(final Sender o) {
+        return bytes.compareTo(o.bytes);
+    }
+
+    @Override
+    public String toString() {
+        return "Sender{" + "id=" + bytes + '}';
+    }
+}

--- a/src/main/java/rx/broadcast/SingleSourceFifoOrder.java
+++ b/src/main/java/rx/broadcast/SingleSourceFifoOrder.java
@@ -16,9 +16,9 @@ public final class SingleSourceFifoOrder<T> implements BroadcastOrder<Timestampe
 
     private final Clock clock = new LamportClock();
 
-    private final Map<Long, SortedSet<Timestamped<T>>> pendingQueues;
+    private final Map<Sender, SortedSet<Timestamped<T>>> pendingQueues;
 
-    private final Map<Long, Long> expectedTimestamps;
+    private final Map<Sender, Long> expectedTimestamps;
 
     private final boolean dropLateMessages;
 
@@ -39,7 +39,7 @@ public final class SingleSourceFifoOrder<T> implements BroadcastOrder<Timestampe
     }
 
     @Override
-    public void receive(final long sender, final Consumer<T> consumer, final Timestamped<T> value) {
+    public void receive(final Sender sender, final Consumer<T> consumer, final Timestamped<T> value) {
         expectedTimestamps.computeIfAbsent(sender, k -> 0L);
 
         if (dropLateMessages) {

--- a/src/main/java/rx/broadcast/UdpBroadcast.java
+++ b/src/main/java/rx/broadcast/UdpBroadcast.java
@@ -15,9 +15,11 @@ import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
 public final class UdpBroadcast<A> implements Broadcast {
-    private static final int MAX_UDP_PACKET_SIZE = 65535;
+    private static final int BYTES_INT_PORT = 4;
 
-    private static final int BYTES_LONG = 8;
+    private static final int BYTES_IPV6_ADDRESS = 16;
+
+    private static final int MAX_UDP_PACKET_SIZE = 65535;
 
     private final DatagramSocket socket;
 
@@ -99,9 +101,10 @@ public final class UdpBroadcast<A> implements Broadcast {
                 break;
             }
 
-            final InetAddress address = packet.getAddress();
-            final int port = packet.getPort();
-            final long sender = ByteBuffer.allocate(BYTES_LONG).put(address.getAddress()).putInt(port).getLong(0);
+            final Sender sender = new Sender(ByteBuffer.allocate(BYTES_IPV6_ADDRESS + BYTES_INT_PORT)
+                .put(packet.getAddress().getAddress())
+                .putInt(packet.getPort())
+                .array());
             final byte[] data = Arrays.copyOf(buffer, packet.getLength());
             try {
                 order.receive(sender, consumer, serializer.decode(data));

--- a/src/main/java/rx/broadcast/VectorTimestamp.java
+++ b/src/main/java/rx/broadcast/VectorTimestamp.java
@@ -7,7 +7,7 @@ import java.util.stream.Stream;
 final class VectorTimestamp implements Serializable {
     private static final long serialVersionUID = 114L;
 
-    private long[] ids;
+    private Sender[] ids;
 
     private long[] timestamps;
 
@@ -16,7 +16,7 @@ final class VectorTimestamp implements Serializable {
 
     }
 
-    VectorTimestamp(final long[] ids, final long[] timestamps) {
+    VectorTimestamp(final Sender[] ids, final long[] timestamps) {
         if (ids.length != timestamps.length) {
             throw new IllegalArgumentException("IDs and timestamps must contain the same number of elements");
         }

--- a/src/main/java/rx/broadcast/VectorTimestampEntry.java
+++ b/src/main/java/rx/broadcast/VectorTimestampEntry.java
@@ -5,7 +5,7 @@ package rx.broadcast;
  * a process or machine in some literature).
  */
 final class VectorTimestampEntry {
-    final long id;
+    final Sender id;
 
     final long timestamp;
 
@@ -14,7 +14,7 @@ final class VectorTimestampEntry {
      * @param id an ID
      * @param timestamp the timestamp value
      */
-    VectorTimestampEntry(final long id, final long timestamp) {
+    VectorTimestampEntry(final Sender id, final long timestamp) {
         this.id = id;
         this.timestamp = timestamp;
     }
@@ -25,6 +25,6 @@ final class VectorTimestampEntry {
      */
     @Override
     public String toString() {
-        return String.format("(%d, %d)", id, timestamp);
+        return String.format("(%s, %d)", id, timestamp);
     }
 }

--- a/src/main/proto/rx/broadcast/VectorTimestamped.proto
+++ b/src/main/proto/rx/broadcast/VectorTimestamped.proto
@@ -4,7 +4,7 @@ option java_package = "rx.broadcast";
 option java_outer_classname = "ProtobufVectorTimestamped";
 
 message VectorTimestamped {
-    repeated uint64 ids = 1 [packed=true];
+    repeated bytes ids = 1;
     repeated uint64 timestamps = 2 [packed=true];
     required bytes value = 3;
 }

--- a/src/test/java/rx/broadcast/CausalOrderTest.java
+++ b/src/test/java/rx/broadcast/CausalOrderTest.java
@@ -7,6 +7,18 @@ import rx.observers.TestSubscriber;
 import java.util.Arrays;
 
 public class CausalOrderTest {
+    private static Sender[] arrayOf(final Sender... buffers) {
+        return buffers;
+    }
+
+    private static Sender sender(final int... args) {
+        final byte[] bytes = new byte[args.length];
+        for (int i = 0; i < args.length; i++) {
+            bytes[i] = (byte) args[i];
+        }
+        return new Sender(bytes);
+    }
+
     /**
      * Returns a new {@link VectorTimestamped<TestValue>}.
      * @param value the test value
@@ -16,7 +28,7 @@ public class CausalOrderTest {
      */
     private static VectorTimestamped<TestValue> timestampedValue(
         final int value,
-        final long[] identifiers,
+        final Sender[] identifiers,
         final long[] clocks
     ) {
         return new VectorTimestamped<>(new TestValue(value), new VectorTimestamp(identifiers, clocks));
@@ -24,15 +36,15 @@ public class CausalOrderTest {
 
     @Test
     public final void receiveMessagesFromSingleSourceInOrder() {
-        final VectorTimestamped<TestValue> value0 = timestampedValue(42, new long[]{0}, new long[]{0});
-        final VectorTimestamped<TestValue> value1 = timestampedValue(43, new long[]{0}, new long[]{1});
-        final VectorTimestamped<TestValue> value2 = timestampedValue(44, new long[]{0}, new long[]{2});
+        final VectorTimestamped<TestValue> value0 = timestampedValue(42, arrayOf(sender(0)), new long[]{0});
+        final VectorTimestamped<TestValue> value1 = timestampedValue(43, arrayOf(sender(0)), new long[]{1});
+        final VectorTimestamped<TestValue> value2 = timestampedValue(44, arrayOf(sender(0)), new long[]{2});
         final CausalOrder<TestValue> causalOrder = new CausalOrder<>();
         final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
 
-        causalOrder.receive(0, consumer::onNext, value0);
-        causalOrder.receive(0, consumer::onNext, value1);
-        causalOrder.receive(0, consumer::onNext, value2);
+        causalOrder.receive(new Sender(new byte[] {0}), consumer::onNext, value0);
+        causalOrder.receive(new Sender(new byte[] {0}), consumer::onNext, value1);
+        causalOrder.receive(new Sender(new byte[] {0}), consumer::onNext, value2);
 
         consumer.assertReceivedOnNext(Arrays.asList(value0.value, value1.value, value2.value));
         Assert.assertEquals(0, causalOrder.queueSize());
@@ -58,13 +70,15 @@ public class CausalOrderTest {
      */
     @Test
     public final void receiveMessagesInCausalOrder() {
-        final VectorTimestamped<TestValue> value0 = timestampedValue(42, new long[]{2}, new long[]{0});
-        final VectorTimestamped<TestValue> value1 = timestampedValue(43, new long[]{1, 2}, new long[]{0, 0});
+        final Sender sender1 = sender(1);
+        final Sender sender2 = sender(2);
+        final VectorTimestamped<TestValue> value0 = timestampedValue(42, arrayOf(sender2), new long[]{0});
+        final VectorTimestamped<TestValue> value1 = timestampedValue(43, arrayOf(sender1, sender2), new long[]{0, 0});
         final CausalOrder<TestValue> causalOrder = new CausalOrder<>();
         final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
 
-        causalOrder.receive(1, consumer::onNext, value1);
-        causalOrder.receive(2, consumer::onNext, value0);
+        causalOrder.receive(sender1, consumer::onNext, value1);
+        causalOrder.receive(sender2, consumer::onNext, value0);
 
         consumer.assertReceivedOnNext(Arrays.asList(value0.value, value1.value));
         Assert.assertEquals(0, causalOrder.queueSize());
@@ -75,15 +89,17 @@ public class CausalOrderTest {
      */
     @Test
     public final void receiveDuplicateMessagesInCausalOrder() {
-        final VectorTimestamped<TestValue> value0 = timestampedValue(42, new long[]{2}, new long[]{0});
-        final VectorTimestamped<TestValue> value1 = timestampedValue(43, new long[]{1, 2}, new long[]{0, 0});
+        final Sender sender1 = sender(1);
+        final Sender sender2 = sender(2);
+        final VectorTimestamped<TestValue> value0 = timestampedValue(42, arrayOf(sender2), new long[]{0});
+        final VectorTimestamped<TestValue> value1 = timestampedValue(43, arrayOf(sender1, sender2), new long[]{0, 0});
         final CausalOrder<TestValue> causalOrder = new CausalOrder<>();
         final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
 
-        causalOrder.receive(1, consumer::onNext, value1);
-        causalOrder.receive(1, consumer::onNext, value1);
-        causalOrder.receive(2, consumer::onNext, value0);
-        causalOrder.receive(2, consumer::onNext, value0);
+        causalOrder.receive(sender1, consumer::onNext, value1);
+        causalOrder.receive(sender1, consumer::onNext, value1);
+        causalOrder.receive(sender2, consumer::onNext, value0);
+        causalOrder.receive(sender2, consumer::onNext, value0);
 
         consumer.assertReceivedOnNext(Arrays.asList(value0.value, value1.value));
     }

--- a/src/test/java/rx/broadcast/SingleSourceFifoOrderTest.java
+++ b/src/test/java/rx/broadcast/SingleSourceFifoOrderTest.java
@@ -4,42 +4,46 @@ import org.junit.Assert;
 import org.junit.Test;
 import rx.observers.TestSubscriber;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 @SuppressWarnings({"Duplicates", "checkstyle:MagicNumber"})
 public class SingleSourceFifoOrderTest {
     @Test
     public final void receiveMessagesInOrder() {
+        final Sender sender1 = new Sender(new byte[]{0});
         final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
         final Timestamped<TestValue> value0 = new Timestamped<>(0, new TestValue(41));
         final Timestamped<TestValue> value1 = new Timestamped<>(1, new TestValue(42));
         final Timestamped<TestValue> value2 = new Timestamped<>(2, new TestValue(43));
         final SingleSourceFifoOrder<TestValue> ssf = new SingleSourceFifoOrder<>();
 
-        ssf.receive(0, consumer::onNext, value0);
-        ssf.receive(0, consumer::onNext, value1);
-        ssf.receive(0, consumer::onNext, value2);
+        ssf.receive(sender1, consumer::onNext, value0);
+        ssf.receive(sender1, consumer::onNext, value1);
+        ssf.receive(sender1, consumer::onNext, value2);
 
         consumer.assertReceivedOnNext(Arrays.asList(value0.value, value1.value, value2.value));
     }
 
     @Test
     public final void receiveMessagesOutOfOrder() {
+        final Sender sender1 = new Sender(new byte[]{0});
         final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
         final Timestamped<TestValue> value0 = new Timestamped<>(0, new TestValue(41));
         final Timestamped<TestValue> value1 = new Timestamped<>(1, new TestValue(42));
         final Timestamped<TestValue> value2 = new Timestamped<>(2, new TestValue(43));
         final SingleSourceFifoOrder<TestValue> ssf = new SingleSourceFifoOrder<>();
 
-        ssf.receive(0, consumer::onNext, value1);
-        ssf.receive(0, consumer::onNext, value0);
-        ssf.receive(0, consumer::onNext, value2);
+        ssf.receive(sender1, consumer::onNext, value1);
+        ssf.receive(sender1, consumer::onNext, value0);
+        ssf.receive(sender1, consumer::onNext, value2);
 
         consumer.assertReceivedOnNext(Arrays.asList(value0.value, value1.value, value2.value));
     }
 
     @Test
     public final void receiveMessagesInReverseOrder() {
+        final Sender sender1 = new Sender(new byte[]{0});
         final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
         final Timestamped<TestValue> value0 = new Timestamped<>(0, new TestValue(41));
         final Timestamped<TestValue> value1 = new Timestamped<>(1, new TestValue(42));
@@ -47,16 +51,17 @@ public class SingleSourceFifoOrderTest {
         final Timestamped<TestValue> value3 = new Timestamped<>(3, new TestValue(44));
         final SingleSourceFifoOrder<TestValue> ssf = new SingleSourceFifoOrder<>();
 
-        ssf.receive(0, consumer::onNext, value3);
-        ssf.receive(0, consumer::onNext, value2);
-        ssf.receive(0, consumer::onNext, value1);
-        ssf.receive(0, consumer::onNext, value0);
+        ssf.receive(sender1, consumer::onNext, value3);
+        ssf.receive(sender1, consumer::onNext, value2);
+        ssf.receive(sender1, consumer::onNext, value1);
+        ssf.receive(sender1, consumer::onNext, value0);
 
         consumer.assertReceivedOnNext(Arrays.asList(value0.value, value1.value, value2.value, value3.value));
     }
 
     @Test
     public final void receiveMessagesWithDropLateFlagDoesDropLateMessages() {
+        final Sender sender1 = new Sender(new byte[]{0});
         final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
         final Timestamped<TestValue> value0 = new Timestamped<>(0, new TestValue(41));
         final Timestamped<TestValue> value1 = new Timestamped<>(1, new TestValue(42));
@@ -64,16 +69,17 @@ public class SingleSourceFifoOrderTest {
         final Timestamped<TestValue> value3 = new Timestamped<>(3, new TestValue(44));
         final SingleSourceFifoOrder<TestValue> ssf = new SingleSourceFifoOrder<>(SingleSourceFifoOrder.DROP_LATE);
 
-        ssf.receive(0, consumer::onNext, value2);
-        ssf.receive(0, consumer::onNext, value0);
-        ssf.receive(0, consumer::onNext, value1);
-        ssf.receive(0, consumer::onNext, value3);
+        ssf.receive(sender1, consumer::onNext, value2);
+        ssf.receive(sender1, consumer::onNext, value0);
+        ssf.receive(sender1, consumer::onNext, value1);
+        ssf.receive(sender1, consumer::onNext, value3);
 
         consumer.assertReceivedOnNext(Arrays.asList(value2.value, value3.value));
     }
 
     @Test
     public final void receiveDuplicateMessagesInOrder() {
+        final Sender sender1 = new Sender(new byte[]{0});
         final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
         final Timestamped<TestValue> value0 = new Timestamped<>(0, new TestValue(41));
         final Timestamped<TestValue> value1 = new Timestamped<>(0, new TestValue(41));
@@ -81,16 +87,17 @@ public class SingleSourceFifoOrderTest {
         final Timestamped<TestValue> value3 = new Timestamped<>(1, new TestValue(42));
         final SingleSourceFifoOrder<TestValue> ssf = new SingleSourceFifoOrder<>();
 
-        ssf.receive(0, consumer::onNext, value0);
-        ssf.receive(0, consumer::onNext, value1);
-        ssf.receive(0, consumer::onNext, value2);
-        ssf.receive(0, consumer::onNext, value3);
+        ssf.receive(sender1, consumer::onNext, value0);
+        ssf.receive(sender1, consumer::onNext, value1);
+        ssf.receive(sender1, consumer::onNext, value2);
+        ssf.receive(sender1, consumer::onNext, value3);
 
         consumer.assertReceivedOnNext(Arrays.asList(value0.value, value2.value));
     }
 
     @Test
     public final void receiveDuplicateMessagesInReverseOrder() {
+        final Sender sender1 = new Sender(new byte[]{0});
         final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
         final Timestamped<TestValue> value0 = new Timestamped<>(0, new TestValue(41));
         final Timestamped<TestValue> value1 = new Timestamped<>(0, new TestValue(41));
@@ -98,18 +105,18 @@ public class SingleSourceFifoOrderTest {
         final Timestamped<TestValue> value3 = new Timestamped<>(1, new TestValue(42));
         final SingleSourceFifoOrder<TestValue> ssf = new SingleSourceFifoOrder<>();
 
-        ssf.receive(0, consumer::onNext, value3);
-        ssf.receive(0, consumer::onNext, value2);
-        ssf.receive(0, consumer::onNext, value1);
-        ssf.receive(0, consumer::onNext, value0);
+        ssf.receive(sender1, consumer::onNext, value3);
+        ssf.receive(sender1, consumer::onNext, value2);
+        ssf.receive(sender1, consumer::onNext, value1);
+        ssf.receive(sender1, consumer::onNext, value0);
 
         consumer.assertReceivedOnNext(Arrays.asList(value0.value, value2.value));
     }
 
     @Test
     public final void receiveUnrelatedMessagesFromTwoSenders() {
-        final long sender1 = -6048052811696954696L;
-        final long sender2 = -6048052815991921992L;
+        final Sender sender1 = new Sender(ByteBuffer.allocate(Long.BYTES).putLong(-6048052811696954696L).array());
+        final Sender sender2 = new Sender(ByteBuffer.allocate(Long.BYTES).putLong(-6048052815991921992L).array());
 
         final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
         final Timestamped<TestValue> value0 = new Timestamped<>(0, new TestValue(40));
@@ -125,8 +132,8 @@ public class SingleSourceFifoOrderTest {
     @SuppressWarnings({"checkstyle:LineLength"})
     @Test
     public final void receiveMessagesFromTwoSendersBothOutOfOrder() {
-        final long sender1 = -6048052811696954696L;
-        final long sender2 = -6048052815991921992L;
+        final Sender sender1 = new Sender(ByteBuffer.allocate(Long.BYTES).putLong(-6048052811696954696L).array());
+        final Sender sender2 = new Sender(ByteBuffer.allocate(Long.BYTES).putLong(-6048052815991921992L).array());
 
         final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
         final Timestamped<TestValue> value0 = new Timestamped<>(0, new TestValue(40));
@@ -146,8 +153,8 @@ public class SingleSourceFifoOrderTest {
 
     @Test
     public final void receiveMessagesFromTwoSendersWithDropLateFlagDoesDropLateMessages() {
-        final long sender1 = -6048052811696954696L;
-        final long sender2 = -6048052815991921992L;
+        final Sender sender1 = new Sender(ByteBuffer.allocate(Long.BYTES).putLong(-6048052811696954696L).array());
+        final Sender sender2 = new Sender(ByteBuffer.allocate(Long.BYTES).putLong(-6048052815991921992L).array());
 
         final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
         final Timestamped<TestValue> value0 = new Timestamped<>(0, new TestValue(41));
@@ -171,8 +178,8 @@ public class SingleSourceFifoOrderTest {
 
     @Test
     public final void receiveDuplicateMessagesFromTwoSendersInOrder() {
-        final long sender1 = -6048052811696954696L;
-        final long sender2 = -6048052815991921992L;
+        final Sender sender1 = new Sender(ByteBuffer.allocate(Long.BYTES).putLong(-6048052811696954696L).array());
+        final Sender sender2 = new Sender(ByteBuffer.allocate(Long.BYTES).putLong(-6048052815991921992L).array());
 
         final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
         final Timestamped<TestValue> value0 = new Timestamped<>(0, new TestValue(41));
@@ -196,8 +203,8 @@ public class SingleSourceFifoOrderTest {
 
     @Test
     public final void receiveDuplicateMessagesFromTwoSendersInReverseOrder() {
-        final long sender1 = -6048052811696954696L;
-        final long sender2 = -6048052815991921992L;
+        final Sender sender1 = new Sender(ByteBuffer.allocate(Long.BYTES).putLong(-6048052811696954696L).array());
+        final Sender sender2 = new Sender(ByteBuffer.allocate(Long.BYTES).putLong(-6048052815991921992L).array());
 
         final TestSubscriber<TestValue> consumer = new TestSubscriber<>();
         final Timestamped<TestValue> value0 = new Timestamped<>(0, new TestValue(41));


### PR DESCRIPTION
Refs #11

This PR introduces IPv6 support by upgrading internal identifiers for senders to 20 bytes (enough for an IPv6 address and port number). I've included scripts for IPv6 testing as well, though they currently cannot be run on Travis CI.