### PR TITLE
Fix Sender implementation of Externalizable/Serializable

### DIFF
--- a/src/main/java/rx/broadcast/Sender.java
+++ b/src/main/java/rx/broadcast/Sender.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.Serializable;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 public final class Sender implements Serializable, Comparable<Sender> {
     private static final long serialVersionUID = 114L;
@@ -31,6 +32,6 @@ public final class Sender implements Serializable, Comparable<Sender> {
 
     @Override
     public String toString() {
-        return "Sender{" + "id=" + bytes + '}';
+        return "Sender{id=" + Arrays.toString(bytes.array()) + '}';
     }
 }

--- a/src/main/java/rx/broadcast/Sender.java
+++ b/src/main/java/rx/broadcast/Sender.java
@@ -2,21 +2,13 @@ package rx.broadcast;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 
-public final class Sender implements Externalizable, Comparable<Sender> {
+public final class Sender implements Serializable, Comparable<Sender> {
     private static final long serialVersionUID = 114L;
 
     private ByteBuffer bytes;
-
-    @Deprecated
-    public Sender() {
-        // This method should not be used
-    }
 
     Sender(final byte[] bytes) {
         this.bytes = ByteBuffer.wrap(bytes);
@@ -40,25 +32,5 @@ public final class Sender implements Externalizable, Comparable<Sender> {
     @Override
     public String toString() {
         return "Sender{" + "id=" + bytes + '}';
-    }
-
-    @Override
-    public void writeExternal(final ObjectOutput out) throws IOException {
-        final byte[] bytes = this.bytes.array();
-        out.writeInt(bytes.length);
-        out.write(bytes);
-    }
-
-    @Override
-    public void readExternal(final ObjectInput in) throws IOException, ClassNotFoundException {
-        final int bufferSize = in.readInt();
-        final byte[] bytes = new byte[bufferSize];
-        final int readSize = in.read(bytes);
-        if (readSize != bufferSize) {
-            throw new IllegalStateException(
-                "The given ObjectInput does not contain the correct number of bytes for this Sender instance");
-        }
-
-        this.bytes = ByteBuffer.wrap(bytes);
     }
 }

--- a/src/main/java/rx/broadcast/Sender.java
+++ b/src/main/java/rx/broadcast/Sender.java
@@ -2,6 +2,8 @@ package rx.broadcast;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -9,9 +11,12 @@ import java.util.Arrays;
 public final class Sender implements Serializable, Comparable<Sender> {
     private static final long serialVersionUID = 114L;
 
-    private ByteBuffer bytes;
+    private final byte[] byteBuffer;
+
+    private transient ByteBuffer bytes;
 
     Sender(final byte[] bytes) {
+        this.byteBuffer = bytes;
         this.bytes = ByteBuffer.wrap(bytes);
     }
 
@@ -33,5 +38,10 @@ public final class Sender implements Serializable, Comparable<Sender> {
     @Override
     public String toString() {
         return "Sender{id=" + Arrays.toString(bytes.array()) + '}';
+    }
+
+    private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        this.bytes = ByteBuffer.wrap(byteBuffer);
     }
 }


### PR DESCRIPTION
Refs #95

This PR changes the way `Sender` implements Java's serialization API to remove the requirement that it have a no-argument constructor. That is, `Sender` now implements [`Serializable`](https://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html) instead of [`Externalizable`](https://docs.oracle.com/javase/8/docs/api/java/io/Externalizable.html) and serializes the underlying `ByteBuffer` array instead of the `ByteBuffer` itself.

The "trick" here is the implementation of `readObject`. From the `Serializable` docs:

> Classes that require special handling during the serialization and deserialization process must implement special methods with these exact signatures:
>
>     private void writeObject(java.io.ObjectOutputStream out)
>         throws IOException
>     private void readObject(java.io.ObjectInputStream in)
>         throws IOException, ClassNotFoundException;
>     private void readObjectNoData()
>         throws ObjectStreamException;
>
> [...]
>
> The readObject method is responsible for reading from the stream and restoring the classes fields. It may call in.defaultReadObject to invoke the default mechanism for restoring the object's non-static and non-transient fields. The defaultReadObject method uses information in the stream to assign the fields of the object saved in the stream with the correspondingly named fields in the current object. This handles the case when the class has evolved to add new fields. The method does not need to concern itself with the state belonging to its superclasses or subclasses. State is saved by writing the individual fields to the ObjectOutputStream using the writeObject method or by using the methods for primitive data types supported by DataOutput.
>
> — [Serializable (Java Platform SE 8)](https://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html)