### PR TITLE
Replace lambdas with methods references in CausalOrder tests

### DIFF
--- a/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrder.java
+++ b/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrder.java
@@ -38,7 +38,7 @@ public class PingPongUdpCausalOrder {
                 ? InetAddress.getByName(System.getProperty("destination"))
                 : InetAddress.getByName("localhost");
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, (host) -> new CausalOrder<>(host));
+                socket, destination, destinationPort, CausalOrder::new);
             final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
 
             broadcast.valuesOfType(Ping.class)
@@ -78,7 +78,7 @@ public class PingPongUdpCausalOrder {
             : InetAddress.getByName("localhost");
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, (host) -> new CausalOrder<>(host));
+                socket, destination, destinationPort, CausalOrder::new);
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)

--- a/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrderKryoSerializer.java
+++ b/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrderKryoSerializer.java
@@ -38,7 +38,7 @@ public class PingPongUdpCausalOrderKryoSerializer {
                 ? InetAddress.getByName(System.getProperty("destination"))
                 : InetAddress.getByName("localhost");
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new KryoSerializer<>(), (host) -> new CausalOrder<>(host));
+                socket, destination, destinationPort, new KryoSerializer<>(), CausalOrder::new);
             final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
 
             broadcast.valuesOfType(Ping.class)
@@ -78,7 +78,7 @@ public class PingPongUdpCausalOrderKryoSerializer {
             : InetAddress.getByName("localhost");
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new KryoSerializer<>(), (host) -> new CausalOrder<>(host));
+                socket, destination, destinationPort, new KryoSerializer<>(), CausalOrder::new);
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)

--- a/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrderObjectSerializer.java
+++ b/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrderObjectSerializer.java
@@ -38,7 +38,7 @@ public class PingPongUdpCausalOrderObjectSerializer {
             : InetAddress.getByName("localhost");
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new ObjectSerializer<>(), (host) -> new CausalOrder<>(host));
+                socket, destination, destinationPort, new ObjectSerializer<>(), CausalOrder::new);
             final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
 
             broadcast.valuesOfType(Ping.class)
@@ -78,7 +78,7 @@ public class PingPongUdpCausalOrderObjectSerializer {
             : InetAddress.getByName("localhost");
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new ObjectSerializer<>(), (host) -> new CausalOrder<>(host));
+                socket, destination, destinationPort, new ObjectSerializer<>(), CausalOrder::new);
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)

--- a/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrderProtobufSerializer.java
+++ b/src/test/java/rx/broadcast/integration/pp/PingPongUdpCausalOrderProtobufSerializer.java
@@ -41,8 +41,7 @@ public class PingPongUdpCausalOrderProtobufSerializer {
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Serializer<Object> s = new ObjectSerializer<>();
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new CausalOrderProtobufSerializer<>(s),
-                (host) -> new CausalOrder<>(host));
+                socket, destination, destinationPort, new CausalOrderProtobufSerializer<>(s), CausalOrder::new);
             final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
 
             broadcast.valuesOfType(Ping.class)
@@ -83,8 +82,7 @@ public class PingPongUdpCausalOrderProtobufSerializer {
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Serializer<Object> s = new ObjectSerializer<>();
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new CausalOrderProtobufSerializer<>(s),
-                (host) -> new CausalOrder<>(host));
+                socket, destination, destinationPort, new CausalOrderProtobufSerializer<>(s), CausalOrder::new);
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)


### PR DESCRIPTION
.