### PR TITLE
Use InetSocketAddress for the destination in UdpBroadcast constructor

### DIFF
--- a/src/test/java/rxbroadcast/UdpBroadcastTest.java
+++ b/src/test/java/rxbroadcast/UdpBroadcastTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -49,9 +50,9 @@ public class UdpBroadcastTest {
         final DatagramSocket s1 = datagramSocketSupplier.get();
         final DatagramSocket s2 = datagramSocketSupplier.get();
         final Broadcast broadcast1 = new UdpBroadcast<>(
-            s1, InetAddress.getLoopbackAddress(), s2.getLocalPort(), new NoOrder<>());
+            s1, new InetSocketAddress(InetAddress.getLoopbackAddress(), s2.getLocalPort()), new NoOrder<>());
         final Broadcast broadcast2 = new UdpBroadcast<>(
-            s2, InetAddress.getLoopbackAddress(), s1.getLocalPort(), new NoOrder<>());
+            s2, new InetSocketAddress(InetAddress.getLoopbackAddress(), s1.getLocalPort()), new NoOrder<>());
 
         broadcast2.valuesOfType(TestValue.class).first().subscribe(subscriber);
         broadcast1.send(new TestValue(42)).toBlocking().subscribe();
@@ -70,9 +71,9 @@ public class UdpBroadcastTest {
         final DatagramSocket s1 = datagramSocketSupplier.get();
         final DatagramSocket s2 = datagramSocketSupplier.get();
         final Broadcast broadcast1 = new UdpBroadcast<>(
-            s1, InetAddress.getLoopbackAddress(), s2.getLocalPort(), new NoOrder<>());
+            s1, new InetSocketAddress(InetAddress.getLoopbackAddress(), s2.getLocalPort()), new NoOrder<>());
         final Broadcast broadcast2 = new UdpBroadcast<>(
-            s2, InetAddress.getLoopbackAddress(), s1.getLocalPort(), new NoOrder<>());
+            s2, new InetSocketAddress(InetAddress.getLoopbackAddress(), s1.getLocalPort()), new NoOrder<>());
 
         broadcast2.valuesOfType(TestValue.class).take(4).subscribe(subscriber);
 
@@ -97,7 +98,7 @@ public class UdpBroadcastTest {
         final DatagramSocket s1 = datagramSocketSupplier.get();
         final DatagramSocket s2 = datagramSocketSupplier.get();
         final Broadcast broadcast1 = new UdpBroadcast<>(
-            s1, InetAddress.getLoopbackAddress(), s2.getLocalPort(), new NoOrder<>());
+            s1, new InetSocketAddress(InetAddress.getLoopbackAddress(), s2.getLocalPort()), new NoOrder<>());
 
         s1.close();
         broadcast1.send(new TestValue(42)).toBlocking().subscribe(subscriber);
@@ -113,9 +114,9 @@ public class UdpBroadcastTest {
         final DatagramSocket s1 = datagramSocketSupplier.get();
         final DatagramSocket s2 = datagramSocketSupplier.get();
         final Broadcast broadcast1 = new UdpBroadcast<>(
-            s1, InetAddress.getLoopbackAddress(), s2.getLocalPort(), new NoOrder<>());
+            s1, new InetSocketAddress(InetAddress.getLoopbackAddress(), s2.getLocalPort()), new NoOrder<>());
         final Broadcast broadcast2 = new UdpBroadcast<>(
-            s2, InetAddress.getLoopbackAddress(), s1.getLocalPort(), new NoOrder<>());
+            s2, new InetSocketAddress(InetAddress.getLoopbackAddress(), s1.getLocalPort()), new NoOrder<>());
 
         broadcast2.valuesOfType(TestValue.class).take(4).subscribe(subscriber);
 
@@ -138,9 +139,9 @@ public class UdpBroadcastTest {
         final DatagramSocket s1 = datagramSocketSupplier.get();
         final DatagramSocket s2 = datagramSocketSupplier.get();
         final Broadcast broadcast1 = new UdpBroadcast<>(
-            s1, InetAddress.getLoopbackAddress(), s2.getLocalPort(), new NoOrder<>());
+            s1, new InetSocketAddress(InetAddress.getLoopbackAddress(), s2.getLocalPort()), new NoOrder<>());
         final Broadcast broadcast2 = new UdpBroadcast<>(
-            s2, InetAddress.getLoopbackAddress(), s1.getLocalPort(), new NoOrder<>());
+            s2, new InetSocketAddress(InetAddress.getLoopbackAddress(), s1.getLocalPort()), new NoOrder<>());
 
         broadcast2.valuesOfType(TestValue.class)
             .take(4)

--- a/src/test/java/rxbroadcast/integration/NoOrderUdpBroadcastTest.java
+++ b/src/test/java/rxbroadcast/integration/NoOrderUdpBroadcastTest.java
@@ -11,6 +11,7 @@ import rx.observers.TestSubscriber;
 
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
@@ -28,7 +29,8 @@ public final class NoOrderUdpBroadcastTest {
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final TestSubscriber<TestValue> subscriber = new TestSubscriber<>();
             final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
-            final Broadcast broadcast = new UdpBroadcast<>(socket, destination, port, new NoOrder<>());
+            final Broadcast broadcast = new UdpBroadcast<>(
+                socket, new InetSocketAddress(destination, port), new NoOrder<>());
 
             broadcast.valuesOfType(TestValue.class).take(MESSAGE_COUNT).subscribe(subscriber);
 
@@ -42,7 +44,8 @@ public final class NoOrderUdpBroadcastTest {
         final int port = Integer.parseInt(System.getProperty("port"));
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
-            final Broadcast broadcast = new UdpBroadcast<>(socket, destination, port, new NoOrder<>());
+            final Broadcast broadcast = new UdpBroadcast<>(
+                socket, new InetSocketAddress(destination, port), new NoOrder<>());
 
             Observable.range(1, MESSAGE_COUNT).map(TestValue::new).flatMap(broadcast::send)
                 .toBlocking()

--- a/src/test/java/rxbroadcast/integration/SingleSourceFifoOrderUdpBroadcastTest.java
+++ b/src/test/java/rxbroadcast/integration/SingleSourceFifoOrderUdpBroadcastTest.java
@@ -11,6 +11,7 @@ import rx.observers.TestSubscriber;
 
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
@@ -30,7 +31,8 @@ public final class SingleSourceFifoOrderUdpBroadcastTest {
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final TestSubscriber<TestValue> subscriber = new TestSubscriber<>();
             final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
-            final Broadcast broadcast = new UdpBroadcast<>(socket, destination, port, new SingleSourceFifoOrder<>());
+            final Broadcast broadcast = new UdpBroadcast<>(
+                socket, new InetSocketAddress(destination, port), new SingleSourceFifoOrder<>());
 
             broadcast.valuesOfType(TestValue.class).take(MESSAGE_COUNT).subscribe(subscriber);
 
@@ -45,7 +47,8 @@ public final class SingleSourceFifoOrderUdpBroadcastTest {
         final int port = Integer.parseInt(System.getProperty("port"));
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
-            final Broadcast broadcast = new UdpBroadcast<>(socket, destination, port, new SingleSourceFifoOrder<>());
+            final Broadcast broadcast = new UdpBroadcast<>(
+                socket, new InetSocketAddress(destination, port), new SingleSourceFifoOrder<>());
 
             MESSAGES.flatMap(broadcast::send).toBlocking().subscribe(null, System.err::println);
         }

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpCausalOrder.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpCausalOrder.java
@@ -10,6 +10,7 @@ import rx.observers.TestSubscriber;
 
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
@@ -39,7 +40,7 @@ public class PingPongUdpCausalOrder {
                 ? InetAddress.getByName(System.getProperty("destination"))
                 : InetAddress.getByName("localhost");
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, (host) -> new CausalOrder<>(host));
+                socket, new InetSocketAddress(destination, destinationPort), (host) -> new CausalOrder<>(host));
             final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
 
             broadcast.valuesOfType(Ping.class)
@@ -79,7 +80,7 @@ public class PingPongUdpCausalOrder {
             : InetAddress.getByName("localhost");
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, (host) -> new CausalOrder<>(host));
+                socket, new InetSocketAddress(destination, destinationPort), (host) -> new CausalOrder<>(host));
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpCausalOrderKryoSerializer.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpCausalOrderKryoSerializer.java
@@ -11,6 +11,7 @@ import rx.observers.TestSubscriber;
 
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
@@ -38,8 +39,9 @@ public class PingPongUdpCausalOrderKryoSerializer {
             final InetAddress destination = System.getProperty("destination") != null
                 ? InetAddress.getByName(System.getProperty("destination"))
                 : InetAddress.getByName("localhost");
+            final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new KryoSerializer<>(), (host) -> new CausalOrder<>(host));
+                socket, destinationSocket, new KryoSerializer<>(), (host) -> new CausalOrder<>(host));
             final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
 
             broadcast.valuesOfType(Ping.class)
@@ -77,9 +79,10 @@ public class PingPongUdpCausalOrderKryoSerializer {
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
             : InetAddress.getByName("localhost");
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new KryoSerializer<>(), (host) -> new CausalOrder<>(host));
+                socket, destinationSocket, new KryoSerializer<>(), (host) -> new CausalOrder<>(host));
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpCausalOrderObjectSerializer.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpCausalOrderObjectSerializer.java
@@ -11,6 +11,7 @@ import rx.observers.TestSubscriber;
 
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
@@ -37,9 +38,10 @@ public class PingPongUdpCausalOrderObjectSerializer {
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
             : InetAddress.getByName("localhost");
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new ObjectSerializer<>(), (host) -> new CausalOrder<>(host));
+                socket, destinationSocket, new ObjectSerializer<>(), (host) -> new CausalOrder<>(host));
             final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
 
             broadcast.valuesOfType(Ping.class)
@@ -77,9 +79,10 @@ public class PingPongUdpCausalOrderObjectSerializer {
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
             : InetAddress.getByName("localhost");
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new ObjectSerializer<>(), (host) -> new CausalOrder<>(host));
+                socket, destinationSocket, new ObjectSerializer<>(), (host) -> new CausalOrder<>(host));
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpCausalOrderProtobufSerializer.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpCausalOrderProtobufSerializer.java
@@ -13,6 +13,7 @@ import rx.observers.TestSubscriber;
 
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
@@ -39,11 +40,11 @@ public class PingPongUdpCausalOrderProtobufSerializer {
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
             : InetAddress.getByName("localhost");
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Serializer<Object> s = new ObjectSerializer<>();
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new CausalOrderProtobufSerializer<>(s),
-                (host) -> new CausalOrder<>(host));
+                socket, destinationSocket, new CausalOrderProtobufSerializer<>(s), (host) -> new CausalOrder<>(host));
             final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
 
             broadcast.valuesOfType(Ping.class)
@@ -81,11 +82,11 @@ public class PingPongUdpCausalOrderProtobufSerializer {
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
             : InetAddress.getByName("localhost");
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Serializer<Object> s = new ObjectSerializer<>();
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new CausalOrderProtobufSerializer<>(s),
-                (host) -> new CausalOrder<>(host));
+                socket, destinationSocket, new CausalOrderProtobufSerializer<>(s), (host) -> new CausalOrder<>(host));
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpNoOrder.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpNoOrder.java
@@ -9,7 +9,7 @@ import rx.Observable;
 import rx.observers.TestSubscriber;
 
 import java.net.DatagramSocket;
-import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
@@ -27,9 +27,9 @@ public class PingPongUdpNoOrder {
     @Test
     public final void recv() throws SocketException, UnknownHostException {
         final int port = Integer.parseInt(System.getProperty("port"));
-        final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
+        final InetSocketAddress destination = new InetSocketAddress(System.getProperty("destination"), port);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
-            final Broadcast broadcast = new UdpBroadcast<>(socket, destination, port, new NoOrder<>());
+            final Broadcast broadcast = new UdpBroadcast<>(socket, destination, new NoOrder<>());
 
             final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
 
@@ -60,9 +60,9 @@ public class PingPongUdpNoOrder {
      */
     public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
         final int port = Integer.parseInt(System.getProperty("port"));
-        final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
+        final InetSocketAddress destination = new InetSocketAddress(System.getProperty("destination"), port);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
-            final Broadcast broadcast = new UdpBroadcast<>(socket, destination, port, new NoOrder<>());
+            final Broadcast broadcast = new UdpBroadcast<>(socket, destination, new NoOrder<>());
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpNoOrderKryoSerializer.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpNoOrderKryoSerializer.java
@@ -10,7 +10,7 @@ import rx.Observable;
 import rx.observers.TestSubscriber;
 
 import java.net.DatagramSocket;
-import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
@@ -28,10 +28,10 @@ public class PingPongUdpNoOrderKryoSerializer {
     @Test
     public final void recv() throws SocketException, UnknownHostException {
         final int port = Integer.parseInt(System.getProperty("port"));
-        final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
+        final InetSocketAddress destination = new InetSocketAddress(System.getProperty("destination"), port);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, port, new KryoSerializer<>(), new NoOrder<>());
+                socket, destination, new KryoSerializer<>(), new NoOrder<>());
 
             final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
 
@@ -62,10 +62,10 @@ public class PingPongUdpNoOrderKryoSerializer {
      */
     public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
         final int port = Integer.parseInt(System.getProperty("port"));
-        final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
+        final InetSocketAddress destination = new InetSocketAddress(System.getProperty("destination"), port);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, port, new KryoSerializer<>(), new NoOrder<>());
+                socket, destination, new KryoSerializer<>(), new NoOrder<>());
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpNoOrderObjectSerializer.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpNoOrderObjectSerializer.java
@@ -10,7 +10,7 @@ import rx.Observable;
 import rx.observers.TestSubscriber;
 
 import java.net.DatagramSocket;
-import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
@@ -28,10 +28,10 @@ public class PingPongUdpNoOrderObjectSerializer {
     @Test
     public final void recv() throws SocketException, UnknownHostException {
         final int port = Integer.parseInt(System.getProperty("port"));
-        final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
+        final InetSocketAddress destination = new InetSocketAddress(System.getProperty("destination"), port);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, port, new ObjectSerializer<>(), new NoOrder<>());
+                socket, destination, new ObjectSerializer<>(), new NoOrder<>());
 
             final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
 
@@ -62,10 +62,10 @@ public class PingPongUdpNoOrderObjectSerializer {
      */
     public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
         final int port = Integer.parseInt(System.getProperty("port"));
-        final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
+        final InetSocketAddress destination = new InetSocketAddress(System.getProperty("destination"), port);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, port, new ObjectSerializer<>(), new NoOrder<>());
+                socket, destination, new ObjectSerializer<>(), new NoOrder<>());
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpSingleSourceFifoOrder.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpSingleSourceFifoOrder.java
@@ -10,6 +10,7 @@ import rx.observers.TestSubscriber;
 
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
@@ -36,8 +37,9 @@ public class PingPongUdpSingleSourceFifoOrder {
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
             : InetAddress.getByName("localhost");
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
-            final Broadcast broadcast = new UdpBroadcast<>(socket, destination, destinationPort, new SingleSourceFifoOrder<>());
+            final Broadcast broadcast = new UdpBroadcast<>(socket, destinationSocket, new SingleSourceFifoOrder<>());
             final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
 
             broadcast.valuesOfType(Ping.class)
@@ -75,8 +77,9 @@ public class PingPongUdpSingleSourceFifoOrder {
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
             : InetAddress.getByName("localhost");
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
-            final Broadcast broadcast = new UdpBroadcast<>(socket, destination, destinationPort, new SingleSourceFifoOrder<>());
+            final Broadcast broadcast = new UdpBroadcast<>(socket, destinationSocket, new SingleSourceFifoOrder<>());
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpSingleSourceFifoOrderKryoSerializer.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpSingleSourceFifoOrderKryoSerializer.java
@@ -11,6 +11,7 @@ import rx.observers.TestSubscriber;
 
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
@@ -37,9 +38,10 @@ public class PingPongUdpSingleSourceFifoOrderKryoSerializer {
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
             : InetAddress.getByName("localhost");
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new KryoSerializer<>(), new SingleSourceFifoOrder<>());
+                socket, destinationSocket, new KryoSerializer<>(), new SingleSourceFifoOrder<>());
             final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
 
             broadcast.valuesOfType(Ping.class)
@@ -77,9 +79,10 @@ public class PingPongUdpSingleSourceFifoOrderKryoSerializer {
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
             : InetAddress.getByName("localhost");
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new KryoSerializer<>(), new SingleSourceFifoOrder<>());
+                socket, destinationSocket, new KryoSerializer<>(), new SingleSourceFifoOrder<>());
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpSingleSourceFifoOrderObjectSerializer.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpSingleSourceFifoOrderObjectSerializer.java
@@ -11,6 +11,7 @@ import rx.observers.TestSubscriber;
 
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
@@ -37,9 +38,10 @@ public class PingPongUdpSingleSourceFifoOrderObjectSerializer {
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
             : InetAddress.getByName("localhost");
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new ObjectSerializer<>(), new SingleSourceFifoOrder<>());
+                socket, destinationSocket, new ObjectSerializer<>(), new SingleSourceFifoOrder<>());
             final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
 
             broadcast.valuesOfType(Ping.class)
@@ -77,9 +79,10 @@ public class PingPongUdpSingleSourceFifoOrderObjectSerializer {
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
             : InetAddress.getByName("localhost");
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new ObjectSerializer<>(), new SingleSourceFifoOrder<>());
+                socket, destinationSocket, new ObjectSerializer<>(), new SingleSourceFifoOrder<>());
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpSingleSourceFifoOrderProtobufSerializer.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpSingleSourceFifoOrderProtobufSerializer.java
@@ -13,6 +13,7 @@ import rx.observers.TestSubscriber;
 
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
@@ -39,10 +40,11 @@ public class PingPongUdpSingleSourceFifoOrderProtobufSerializer {
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
             : InetAddress.getByName("localhost");
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Serializer<Object> s = new ObjectSerializer<>();
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new SingleSourceFifoOrderProtobufSerializer<>(s), new SingleSourceFifoOrder<>());
+                socket, destinationSocket, new SingleSourceFifoOrderProtobufSerializer<>(s), new SingleSourceFifoOrder<>());
             final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
 
             broadcast.valuesOfType(Ping.class)
@@ -80,10 +82,11 @@ public class PingPongUdpSingleSourceFifoOrderProtobufSerializer {
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
             : InetAddress.getByName("localhost");
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Serializer<Object> s = new ObjectSerializer<>();
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, destinationPort, new SingleSourceFifoOrderProtobufSerializer<>(s), new SingleSourceFifoOrder<>());
+                socket, destinationSocket, new SingleSourceFifoOrderProtobufSerializer<>(s), new SingleSourceFifoOrder<>());
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)


### PR DESCRIPTION
This PR updates the `UdpBroadcast` constructor to take a single [`InetSocketAddress`](https://docs.oracle.com/javase/8/docs/api/java/net/InetSocketAddress.html) instance instead of a separate `InetSocketAddress` and `int` for the destination and port. Less constructor arguments the better?