### PR TITLE
Add Oracle JDK 9 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ script:
     - scripts/test-table-tennis rxbroadcast.integration.pp.PingPongUdpCausalOrderObjectSerializer
     - scripts/test-table-tennis rxbroadcast.integration.pp.PingPongUdpCausalOrderProtobufSerializer
 jobs:
+    allow_failures:
+        - stage: "Test"
+          jdk: oraclejdk9
     include:
         - stage: "Static analysis"
           jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
 language: java
 jdk:
     - oraclejdk8
+    - oraclejdk9
     - openjdk8
 before_install:
     - ( cd $HOME && curl -LO "https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip" )


### PR DESCRIPTION
This PR adds the Oracle JDK 9 to the Travis CI build matrix. (This may need to wait for an update to the Kotlin DSL for the build to pass.)