### PR TITLE
Prefer InetAddress.getLoopbackAddress to resolving localhost

### DIFF
--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpCausalOrder.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpCausalOrder.java
@@ -38,7 +38,7 @@ public class PingPongUdpCausalOrder {
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final InetAddress destination = System.getProperty("destination") != null
                 ? InetAddress.getByName(System.getProperty("destination"))
-                : InetAddress.getByName("localhost");
+                : InetAddress.getLoopbackAddress();
             final Broadcast broadcast = new UdpBroadcast<>(
                 socket, new InetSocketAddress(destination, destinationPort), (host) -> new CausalOrder<>(host));
             final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
@@ -77,7 +77,7 @@ public class PingPongUdpCausalOrder {
             : 12345;
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
-            : InetAddress.getByName("localhost");
+            : InetAddress.getLoopbackAddress();
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
                 socket, new InetSocketAddress(destination, destinationPort), (host) -> new CausalOrder<>(host));

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpCausalOrderKryoSerializer.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpCausalOrderKryoSerializer.java
@@ -38,7 +38,7 @@ public class PingPongUdpCausalOrderKryoSerializer {
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final InetAddress destination = System.getProperty("destination") != null
                 ? InetAddress.getByName(System.getProperty("destination"))
-                : InetAddress.getByName("localhost");
+                : InetAddress.getLoopbackAddress();
             final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
             final Broadcast broadcast = new UdpBroadcast<>(
                 socket, destinationSocket, new KryoSerializer<>(), (host) -> new CausalOrder<>(host));
@@ -78,7 +78,7 @@ public class PingPongUdpCausalOrderKryoSerializer {
             : 12345;
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
-            : InetAddress.getByName("localhost");
+            : InetAddress.getLoopbackAddress();
         final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpCausalOrderObjectSerializer.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpCausalOrderObjectSerializer.java
@@ -37,7 +37,7 @@ public class PingPongUdpCausalOrderObjectSerializer {
             : 12345;
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
-            : InetAddress.getByName("localhost");
+            : InetAddress.getLoopbackAddress();
         final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
@@ -78,7 +78,7 @@ public class PingPongUdpCausalOrderObjectSerializer {
             : 12345;
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
-            : InetAddress.getByName("localhost");
+            : InetAddress.getLoopbackAddress();
         final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpCausalOrderProtobufSerializer.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpCausalOrderProtobufSerializer.java
@@ -39,7 +39,7 @@ public class PingPongUdpCausalOrderProtobufSerializer {
             : 12345;
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
-            : InetAddress.getByName("localhost");
+            : InetAddress.getLoopbackAddress();
         final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Serializer<Object> s = new ObjectSerializer<>();
@@ -81,7 +81,7 @@ public class PingPongUdpCausalOrderProtobufSerializer {
             : 12345;
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
-            : InetAddress.getByName("localhost");
+            : InetAddress.getLoopbackAddress();
         final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Serializer<Object> s = new ObjectSerializer<>();

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpSingleSourceFifoOrder.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpSingleSourceFifoOrder.java
@@ -36,7 +36,7 @@ public class PingPongUdpSingleSourceFifoOrder {
             : 12345;
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
-            : InetAddress.getByName("localhost");
+            : InetAddress.getLoopbackAddress();
         final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(socket, destinationSocket, new SingleSourceFifoOrder<>());
@@ -76,7 +76,7 @@ public class PingPongUdpSingleSourceFifoOrder {
             : 12345;
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
-            : InetAddress.getByName("localhost");
+            : InetAddress.getLoopbackAddress();
         final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(socket, destinationSocket, new SingleSourceFifoOrder<>());

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpSingleSourceFifoOrderKryoSerializer.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpSingleSourceFifoOrderKryoSerializer.java
@@ -37,7 +37,7 @@ public class PingPongUdpSingleSourceFifoOrderKryoSerializer {
             : 12345;
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
-            : InetAddress.getByName("localhost");
+            : InetAddress.getLoopbackAddress();
         final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
@@ -78,7 +78,7 @@ public class PingPongUdpSingleSourceFifoOrderKryoSerializer {
             : 12345;
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
-            : InetAddress.getByName("localhost");
+            : InetAddress.getLoopbackAddress();
         final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpSingleSourceFifoOrderObjectSerializer.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpSingleSourceFifoOrderObjectSerializer.java
@@ -37,7 +37,7 @@ public class PingPongUdpSingleSourceFifoOrderObjectSerializer {
             : 12345;
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
-            : InetAddress.getByName("localhost");
+            : InetAddress.getLoopbackAddress();
         final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
@@ -78,7 +78,7 @@ public class PingPongUdpSingleSourceFifoOrderObjectSerializer {
             : 12345;
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
-            : InetAddress.getByName("localhost");
+            : InetAddress.getLoopbackAddress();
         final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpSingleSourceFifoOrderProtobufSerializer.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpSingleSourceFifoOrderProtobufSerializer.java
@@ -39,7 +39,7 @@ public class PingPongUdpSingleSourceFifoOrderProtobufSerializer {
             : 12345;
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
-            : InetAddress.getByName("localhost");
+            : InetAddress.getLoopbackAddress();
         final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Serializer<Object> s = new ObjectSerializer<>();
@@ -81,7 +81,7 @@ public class PingPongUdpSingleSourceFifoOrderProtobufSerializer {
             : 12345;
         final InetAddress destination = System.getProperty("destination") != null
             ? InetAddress.getByName(System.getProperty("destination"))
-            : InetAddress.getByName("localhost");
+            : InetAddress.getLoopbackAddress();
         final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Serializer<Object> s = new ObjectSerializer<>();


### PR DESCRIPTION
This PR replaces usages of `InetAddress.getByName("localhost")` with [`InetAddress.getLoopbackAddress()`](https://docs.oracle.com/javase/8/docs/api/java/net/InetAddress.html#isLoopbackAddress--) to avoid resolving a hostname unnecessarily.