### PR TITLE
Test cases for equals+hashCode implementations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     compile("io.reactivex:rxjava:1.3.0")
     compile("org.jetbrains:annotations:15.0")
     testCompile("junit:junit:4.12")
+    testCompile("nl.jqno.equalsverifier:equalsverifier:2.3.3")
 }
 
 fun linkGitHub(resource: String = "") = "https://github.com/${project.name}/${project.name}$resource"

--- a/src/main/java/rxbroadcast/Sender.java
+++ b/src/main/java/rxbroadcast/Sender.java
@@ -20,6 +20,7 @@ public final class Sender implements Serializable, Comparable<Sender> {
     @NotNull
     final byte[] byteBuffer;
 
+    @Deprecated
     @SuppressWarnings("unused")
     Sender() {
         // This no-arg ctor is for deserialization purposes only

--- a/src/main/java/rxbroadcast/Sender.java
+++ b/src/main/java/rxbroadcast/Sender.java
@@ -17,6 +17,7 @@ public final class Sender implements Serializable, Comparable<Sender> {
 
     private static final int BYTES_SENDER_BUFFER = BYTES_IPV6_ADDRESS + BYTES_INT_PORT;
 
+    @NotNull
     final byte[] byteBuffer;
 
     @SuppressWarnings("unused")
@@ -25,7 +26,7 @@ public final class Sender implements Serializable, Comparable<Sender> {
         this(new byte[0]);
     }
 
-    Sender(final byte[] bytes) {
+    Sender(@NotNull final byte[] bytes) {
         this.byteBuffer = bytes;
     }
 

--- a/src/main/java/rxbroadcast/Timestamped.java
+++ b/src/main/java/rxbroadcast/Timestamped.java
@@ -9,13 +9,14 @@ final class Timestamped<T> implements Comparable<Timestamped<T>>, Serializable {
     private static final long serialVersionUID = 114L;
 
     @SuppressWarnings("WeakerAccess")
-    public long timestamp;
+    public final long timestamp;
 
-    public T value;
+    public final T value;
 
+    @Deprecated
     @SuppressWarnings("unused")
     Timestamped() {
-
+        this(0, null);
     }
 
     Timestamped(final long timestamp, final T value) {

--- a/src/main/java/rxbroadcast/VectorTimestamp.java
+++ b/src/main/java/rxbroadcast/VectorTimestamp.java
@@ -13,18 +13,20 @@ import java.util.stream.Stream;
 final class VectorTimestamp implements Comparable<VectorTimestamp>, Serializable {
     private static final long serialVersionUID = 114L;
 
-    private Integer hashCode = null;
+    private int hashCode;
 
-    private Sender[] ids;
+    @NotNull
+    private final Sender[] ids;
 
-    private long[] timestamps;
+    @NotNull
+    private final long[] timestamps;
 
     @SuppressWarnings("unused")
     VectorTimestamp() {
-
+        this(new Sender[0], new long[0]);
     }
 
-    VectorTimestamp(final Sender[] ids, final long[] timestamps) {
+    VectorTimestamp(@NotNull final Sender[] ids, @NotNull final long[] timestamps) {
         if (ids.length != timestamps.length) {
             throw new IllegalArgumentException("IDs and timestamps must contain the same number of elements");
         }
@@ -78,30 +80,34 @@ final class VectorTimestamp implements Comparable<VectorTimestamp>, Serializable
 
     @Override
     public int hashCode() {
-        if (hashCode == null) {
-            hashCode = Objects.hash(new Object() {
-                @Override
-                public boolean equals(final Object o) {
-                    return this == o;
-                }
-
-                @Override
-                public int hashCode() {
-                    return Arrays.hashCode(ids);
-                }
-            }, new Object() {
-                @Override
-                public boolean equals(final Object o) {
-                    return this == o;
-                }
-
-                @Override
-                public int hashCode() {
-                    return Arrays.hashCode(timestamps);
-                }
-            });
+        if (hashCode == 0) {
+            hashCode = computeHashCode();
         }
 
         return hashCode;
+    }
+
+    private int computeHashCode() {
+        return Objects.hash(new Object() {
+            @Override
+            public boolean equals(final Object o) {
+                return this == o;
+            }
+
+            @Override
+            public int hashCode() {
+                return Arrays.hashCode(ids);
+            }
+        }, new Object() {
+            @Override
+            public boolean equals(final Object o) {
+                return this == o;
+            }
+
+            @Override
+            public int hashCode() {
+                return Arrays.hashCode(timestamps);
+            }
+        });
     }
 }

--- a/src/main/java/rxbroadcast/VectorTimestamped.java
+++ b/src/main/java/rxbroadcast/VectorTimestamped.java
@@ -13,13 +13,15 @@ import java.util.Objects;
 public final class VectorTimestamped<T> implements Comparable<VectorTimestamped<T>>, Serializable {
     private static final long serialVersionUID = 114L;
 
-    public VectorTimestamp timestamp;
+    @NotNull
+    public final VectorTimestamp timestamp;
 
-    public T value;
+    public final T value;
 
+    @Deprecated
     @SuppressWarnings("unused")
     VectorTimestamped() {
-
+        this(null, new VectorTimestamp());
     }
 
     /**
@@ -28,7 +30,7 @@ public final class VectorTimestamped<T> implements Comparable<VectorTimestamped<
      * @param value the timestamped value
      * @param timestamp the timestamp
      */
-    public VectorTimestamped(final T value, final VectorTimestamp timestamp) {
+    public VectorTimestamped(final T value, @NotNull final VectorTimestamp timestamp) {
         this.timestamp = timestamp;
         this.value = value;
     }

--- a/src/main/java/rxbroadcast/time/LamportClock.java
+++ b/src/main/java/rxbroadcast/time/LamportClock.java
@@ -1,5 +1,6 @@
 package rxbroadcast.time;
 
+import java.util.Objects;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.LongFunction;
@@ -80,5 +81,23 @@ public final class LamportClock implements Clock {
     @Override
     public final String toString() {
         return String.format("LamportClock{time=%d}", time);
+    }
+
+    @Override
+    public final boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final LamportClock that = (LamportClock) o;
+        return time == that.time;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(time);
     }
 }

--- a/src/test/java/rxbroadcast/SenderTest.java
+++ b/src/test/java/rxbroadcast/SenderTest.java
@@ -1,0 +1,11 @@
+package rxbroadcast;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+public final class SenderTest {
+    @Test
+    public final void equalsContract() {
+        EqualsVerifier.forClass(Sender.class).verify();
+    }
+}

--- a/src/test/java/rxbroadcast/TimestampedTest.java
+++ b/src/test/java/rxbroadcast/TimestampedTest.java
@@ -1,0 +1,11 @@
+package rxbroadcast;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+public final class TimestampedTest {
+    @Test
+    public final void equalsContract() {
+        EqualsVerifier.forClass(Timestamped.class).verify();
+    }
+}

--- a/src/test/java/rxbroadcast/VectorTimestampTest.java
+++ b/src/test/java/rxbroadcast/VectorTimestampTest.java
@@ -1,0 +1,16 @@
+package rxbroadcast;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+@SuppressWarnings({"checkstyle:MagicNumber"})
+public final class VectorTimestampTest {
+    @Test
+    public final void equalsContract() {
+        EqualsVerifier.forClass(VectorTimestamp.class)
+            .withCachedHashCode("hashCode", "computeHashCode", new VectorTimestamp(
+                new Sender[]{new Sender(new byte[] {42}), new Sender(new byte[]{43})}, new long[]{1, 2}
+            ))
+            .verify();
+    }
+}

--- a/src/test/java/rxbroadcast/VectorTimestampedTest.java
+++ b/src/test/java/rxbroadcast/VectorTimestampedTest.java
@@ -1,0 +1,11 @@
+package rxbroadcast;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+public final class VectorTimestampedTest {
+    @Test
+    public final void equalsContract() {
+        EqualsVerifier.forClass(VectorTimestamped.class).verify();
+    }
+}

--- a/src/test/java/rxbroadcast/time/LamportClockTest.java
+++ b/src/test/java/rxbroadcast/time/LamportClockTest.java
@@ -1,5 +1,7 @@
 package rxbroadcast.time;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
@@ -64,5 +66,13 @@ public final class LamportClockTest {
     public final void toStringDoesNotReturnNull() {
         final LamportClock clock = new LamportClock();
         Assert.assertThat(clock.toString(), CoreMatchers.notNullValue());
+    }
+
+    @Test
+    public final void equalsContract() {
+        EqualsVerifier.forClass(LamportClock.class)
+            .withIgnoredFields("lock")
+            .suppress(Warning.NONFINAL_FIELDS)
+            .verify();
     }
 }


### PR DESCRIPTION
Refs #114

This PR adds test cases for the [`equals`](https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#equals-java.lang.Object-)/[`hashCode`](https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#hashCode--) contracts of a few classes that override them:

- `Timestamped`
- `Sender`
- `VectorTimestamped`
- `VectorTimestamp`
- `LamportClock`
