### PR TITLE
Add IBM JDK 9 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+group: edge
 sudo: required
 dist: trusty
 services:
@@ -13,6 +14,7 @@ jdk:
     - oraclejdk8
     - oraclejdk9
     - openjdk8
+    - ibmjava8
 before_install:
     - ( cd $HOME && curl -LO "https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip" )
     - ( cd $HOME && unzip -q gradle-$GRADLE_VERSION-bin.zip && rm gradle-$GRADLE_VERSION-bin.zip )


### PR DESCRIPTION
This PR adds the official IBM® Java SDK to the build matrix