### PR TITLE
Update Error Prone Gradle plugin to 0.0.13, fix Error Prone version to 2.1.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     findbugs
     pmd
     id("com.jfrog.bintray") version "1.6"
-    id("net.ltgt.errorprone-base") version "0.0.11"
+    id("net.ltgt.errorprone-base") version "0.0.13"
 }
 
 repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     compile("com.google.protobuf:protobuf-java:3.3.1")
     compile("io.reactivex:rxjava:1.3.0")
     compile("org.jetbrains:annotations:15.0")
+    errorprone("com.google.errorprone:error_prone_core:2.1.1")
     testCompile("junit:junit:4.12")
     testCompile("nl.jqno.equalsverifier:equalsverifier:2.3.3")
 }


### PR DESCRIPTION
This PR fixes (in the sense of securing in place) the Error Prone to 2.1.1 and updates the Gradle plugin to 0.0.13. The newest version, 2.1.2, will require edits to the project to fix a few errors.