### PR TITLE
Replace manual socket housekeeping with try-with-resources in some tests

### DIFF
--- a/src/test/java/rxbroadcast/UdpBroadcastOnSubscribeTest.java
+++ b/src/test/java/rxbroadcast/UdpBroadcastOnSubscribeTest.java
@@ -1,59 +1,33 @@
 package rxbroadcast;
 
-import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import rx.observers.TestSubscriber;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.SocketException;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.function.Supplier;
 
 @SuppressWarnings({"checkstyle:MagicNumber"})
 public final class UdpBroadcastOnSubscribeTest {
-    private final List<Closeable> resources = new LinkedList<>();
-
-    private final Supplier<DatagramSocket> datagramSocketSupplier = () -> {
-        try {
-            final DatagramSocket socket = new DatagramSocket();
-            resources.add(socket);
-            return socket;
-        } catch (final SocketException e) {
-            throw new RuntimeException(e);
-        }
-    };
-
     @Rule
     public final Timeout timeout = Timeout.seconds(1);
-
-    @After
-    public final void tearDown() {
-        resources.forEach(closeable -> {
-            try {
-                closeable.close();
-            } catch (final IOException e) {
-                // ???
-            }
-        });
-    }
 
     @Test
     public final void unsubscribeDoesBreakCall() throws SocketException {
         final TestSubscriber<Object> subscriber = new TestSubscriber<>();
-        final UdpBroadcastOnSubscribe<Object> onSubscribe = new UdpBroadcastOnSubscribe<>(
-            datagramSocketSupplier.get(), new ObjectSerializer<>(), new NoOrder<>());
+        try (final DatagramSocket readSocket = new DatagramSocket()) {
+            final UdpBroadcastOnSubscribe<Object> onSubscribe = new UdpBroadcastOnSubscribe<>(
+                readSocket, new ObjectSerializer<>(), new NoOrder<>());
 
-        subscriber.unsubscribe();
-        onSubscribe.call(subscriber);
+            subscriber.unsubscribe();
+            onSubscribe.call(subscriber);
 
-        subscriber.assertNoErrors();
-        subscriber.assertNoValues();
-        subscriber.assertNotCompleted();
+            subscriber.assertNoErrors();
+            subscriber.assertNoValues();
+            subscriber.assertNotCompleted();
+        }
     }
 
     @Test


### PR DESCRIPTION
This PR updates the `UdpBroadcast` tests cases to replace the manual [`DatagramSocket`][1] tracking with try-with-resources blocks. This 1) removes the last two usages of [`LinkedList`][2] from the project in preparation for Error Prone v2.1.2 that flags them and 2) makes the tests more self-contained, which is always nice.

  [1]:https://docs.oracle.com/javase/8/docs/api/java/net/DatagramSocket.html
  [2]:https://docs.oracle.com/javase/8/docs/api/java/util/LinkedList.html