### PR TITLE
Allow IBM JDK failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ jobs:
     allow_failures:
         - stage: "Test"
           jdk: oraclejdk9
+        - stage: "Test"
+          jdk: ibmjava8
     include:
         - stage: "Static analysis"
           jdk: oraclejdk8


### PR DESCRIPTION
Spurred on by the recent failures on the new Gradle branches, I'm allowing this matrix entry to fail.