### PR TITLE
Remove unused INFER_DIR variable from Infer script

### DIFF
--- a/scripts/infer
+++ b/scripts/infer
@@ -4,7 +4,6 @@ set -e
 set -u
 set -o pipefail
 
-INFER_DIR="${INFER_DIRECTORY}/infer-linux64-v${INFER_VERSION}"
 INFER_BIN="${INFER_DIRECTORY}/infer-linux64-v${INFER_VERSION}/infer/bin"
 
 if [[ ! -x "${INFER_BIN}/infer" ]]


### PR DESCRIPTION
[shellcheck.net](https://www.shellcheck.net) informed me that this isn't used. Now it's gone.