### PR TITLE
Warn when the IPv6 flag adjusts the number of JUnit containers

### DIFF
--- a/test/two_way.py
+++ b/test/two_way.py
@@ -64,7 +64,9 @@ if args.ipv6:
     # have different source and destination ports
     source_port = source_port - 1
     dest_port = dest_port + 1
-    num_junit_containers = 1
+    if num_junit_containers > 1:
+        print(colored('Constraining JUnit container count to 1', 'yellow'))
+        num_junit_containers = 1
 
 junit_args = [
     '-Dport={0}'.format(dest_port),

--- a/test/two_way.py
+++ b/test/two_way.py
@@ -88,7 +88,7 @@ colorama.init()
 if len(client.images.list(name='{0.image}:latest'.format(args))) != 1:
     build_image_if_not_exists(client, args.image)
 
-print('Attempting to create {0} JUnit containers'.format(args.num_junit_containers))
+print('Attempting to create {0} JUnit containers'.format(num_junit_containers))
 for i in range(num_junit_containers):
     c = new_container(args.image, command=junit_args, detach=True)
     print(exec_shell_command(args.network_command, env={'DOCKER_IFACE': docker_interface(c).host}).decode(), end='')


### PR DESCRIPTION
Refs #149

When passing `--ipv6` to the two way test script, the number of JUnit containers is limited to 1 (because the containers are using the host network and else multiple containers would be binding to the same port on a single host).