### PR TITLE
Fix integration test properties inconsistencies

### DIFF
--- a/src/test/java/rxbroadcast/integration/SingleSourceFifoOrderUdpBroadcastTest.java
+++ b/src/test/java/rxbroadcast/integration/SingleSourceFifoOrderUdpBroadcastTest.java
@@ -16,6 +16,7 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
 
+@SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:AvoidInlineConditionals"})
 public final class SingleSourceFifoOrderUdpBroadcastTest {
     private static final int MESSAGE_COUNT = 100;
 
@@ -27,12 +28,20 @@ public final class SingleSourceFifoOrderUdpBroadcastTest {
 
     @Test
     public final void receive() throws SocketException, UnknownHostException {
-        final int port = Integer.parseInt(System.getProperty("port"));
+        final int port = System.getProperty("port") != null
+            ? Integer.parseInt(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.parseInt(System.getProperty("destinationPort"))
+            : 12345;
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getLoopbackAddress();
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
+        final TestSubscriber<TestValue> subscriber = new TestSubscriber<>();
         try (final DatagramSocket socket = new DatagramSocket(port)) {
-            final TestSubscriber<TestValue> subscriber = new TestSubscriber<>();
-            final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, new InetSocketAddress(destination, port), new SingleSourceFifoOrder<>());
+                socket, destinationSocket, new SingleSourceFifoOrder<>());
 
             broadcast.valuesOfType(TestValue.class).take(MESSAGE_COUNT).subscribe(subscriber);
 
@@ -44,11 +53,19 @@ public final class SingleSourceFifoOrderUdpBroadcastTest {
     }
 
     public static void main(final String[] args) throws SocketException, UnknownHostException {
-        final int port = Integer.parseInt(System.getProperty("port"));
+        final int port = System.getProperty("port") != null
+            ? Integer.parseInt(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.parseInt(System.getProperty("destinationPort"))
+            : 12345;
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getLoopbackAddress();
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
-            final InetAddress destination = InetAddress.getByName(System.getProperty("destination"));
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, new InetSocketAddress(destination, port), new SingleSourceFifoOrder<>());
+                socket, destinationSocket, new SingleSourceFifoOrder<>());
 
             MESSAGES.flatMap(broadcast::send).toBlocking().subscribe(null, System.err::println);
         }

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpNoOrder.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpNoOrder.java
@@ -9,11 +9,13 @@ import rx.Observable;
 import rx.observers.TestSubscriber;
 
 import java.net.DatagramSocket;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
 
+@SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:AvoidInlineConditionals"})
 public final class PingPongUdpNoOrder {
     private static final int MESSAGE_COUNT = 100;
 
@@ -26,11 +28,19 @@ public final class PingPongUdpNoOrder {
      */
     @Test
     public final void recv() throws SocketException, UnknownHostException {
-        final int port = Integer.parseInt(System.getProperty("port"));
-        final InetSocketAddress destination = new InetSocketAddress(System.getProperty("destination"), port);
+        final int port = System.getProperty("port") != null
+            ? Integer.parseInt(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.parseInt(System.getProperty("destinationPort"))
+            : 12345;
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getLoopbackAddress();
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
         try (final DatagramSocket socket = new DatagramSocket(port)) {
-            final Broadcast broadcast = new UdpBroadcast<>(socket, destination, new NoOrder<>());
+            final Broadcast broadcast = new UdpBroadcast<>(socket, destinationSocket, new NoOrder<>());
 
             broadcast.valuesOfType(Ping.class)
                 .doOnNext(System.out::println)
@@ -58,10 +68,18 @@ public final class PingPongUdpNoOrder {
      * @throws UnknownHostException if no IP address for the host machine could be found.
      */
     public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
-        final int port = Integer.parseInt(System.getProperty("port"));
-        final InetSocketAddress destination = new InetSocketAddress(System.getProperty("destination"), port);
+        final int port = System.getProperty("port") != null
+            ? Integer.parseInt(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.parseInt(System.getProperty("destinationPort"))
+            : 12345;
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getLoopbackAddress();
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
-            final Broadcast broadcast = new UdpBroadcast<>(socket, destination, new NoOrder<>());
+            final Broadcast broadcast = new UdpBroadcast<>(socket, destinationSocket, new NoOrder<>());
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpNoOrderKryoSerializer.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpNoOrderKryoSerializer.java
@@ -10,11 +10,13 @@ import rx.Observable;
 import rx.observers.TestSubscriber;
 
 import java.net.DatagramSocket;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
 
+@SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:AvoidInlineConditionals"})
 public final class PingPongUdpNoOrderKryoSerializer {
     private static final int MESSAGE_COUNT = 100;
 
@@ -27,12 +29,20 @@ public final class PingPongUdpNoOrderKryoSerializer {
      */
     @Test
     public final void recv() throws SocketException, UnknownHostException {
-        final int port = Integer.parseInt(System.getProperty("port"));
-        final InetSocketAddress destination = new InetSocketAddress(System.getProperty("destination"), port);
+        final int port = System.getProperty("port") != null
+            ? Integer.parseInt(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.parseInt(System.getProperty("destinationPort"))
+            : 12345;
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getLoopbackAddress();
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, new KryoSerializer<>(), new NoOrder<>());
+                socket, destinationSocket, new KryoSerializer<>(), new NoOrder<>());
 
             broadcast.valuesOfType(Ping.class)
                 .doOnNext(System.out::println)
@@ -60,11 +70,19 @@ public final class PingPongUdpNoOrderKryoSerializer {
      * @throws UnknownHostException if no IP address for the host machine could be found.
      */
     public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
-        final int port = Integer.parseInt(System.getProperty("port"));
-        final InetSocketAddress destination = new InetSocketAddress(System.getProperty("destination"), port);
+        final int port = System.getProperty("port") != null
+            ? Integer.parseInt(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.parseInt(System.getProperty("destinationPort"))
+            : 12345;
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getLoopbackAddress();
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, new KryoSerializer<>(), new NoOrder<>());
+                socket, destinationSocket, new KryoSerializer<>(), new NoOrder<>());
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)

--- a/src/test/java/rxbroadcast/integration/pp/PingPongUdpNoOrderObjectSerializer.java
+++ b/src/test/java/rxbroadcast/integration/pp/PingPongUdpNoOrderObjectSerializer.java
@@ -10,11 +10,13 @@ import rx.Observable;
 import rx.observers.TestSubscriber;
 
 import java.net.DatagramSocket;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
 
+@SuppressWarnings({"checkstyle:MagicNumber", "checkstyle:AvoidInlineConditionals"})
 public final class PingPongUdpNoOrderObjectSerializer {
     private static final int MESSAGE_COUNT = 100;
 
@@ -27,12 +29,20 @@ public final class PingPongUdpNoOrderObjectSerializer {
      */
     @Test
     public final void recv() throws SocketException, UnknownHostException {
-        final int port = Integer.parseInt(System.getProperty("port"));
-        final InetSocketAddress destination = new InetSocketAddress(System.getProperty("destination"), port);
+        final int port = System.getProperty("port") != null
+            ? Integer.parseInt(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.parseInt(System.getProperty("destinationPort"))
+            : 12345;
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getLoopbackAddress();
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         final TestSubscriber<Ping> subscriber = new TestSubscriber<>();
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, new ObjectSerializer<>(), new NoOrder<>());
+                socket, destinationSocket, new ObjectSerializer<>(), new NoOrder<>());
 
             broadcast.valuesOfType(Ping.class)
                 .doOnNext(System.out::println)
@@ -60,11 +70,19 @@ public final class PingPongUdpNoOrderObjectSerializer {
      * @throws UnknownHostException if no IP address for the host machine could be found.
      */
     public static void main(final String[] args) throws InterruptedException, SocketException, UnknownHostException {
-        final int port = Integer.parseInt(System.getProperty("port"));
-        final InetSocketAddress destination = new InetSocketAddress(System.getProperty("destination"), port);
+        final int port = System.getProperty("port") != null
+            ? Integer.parseInt(System.getProperty("port"))
+            : 54321;
+        final int destinationPort = System.getProperty("destinationPort") != null
+            ? Integer.parseInt(System.getProperty("destinationPort"))
+            : 12345;
+        final InetAddress destination = System.getProperty("destination") != null
+            ? InetAddress.getByName(System.getProperty("destination"))
+            : InetAddress.getLoopbackAddress();
+        final InetSocketAddress destinationSocket = new InetSocketAddress(destination, destinationPort);
         try (final DatagramSocket socket = new DatagramSocket(port)) {
             final Broadcast broadcast = new UdpBroadcast<>(
-                socket, destination, new ObjectSerializer<>(), new NoOrder<>());
+                socket, destinationSocket, new ObjectSerializer<>(), new NoOrder<>());
 
             Observable.range(1, MESSAGE_COUNT)
                 .map(Ping::new)


### PR DESCRIPTION
This PR fixes the inconsistencies in the integration test properties by adding `destinationPort` to all of the integration tests. All tests now have the same three properties (`port`, `destinationPort`, and `destination`) with sane defaults.