### PR TITLE
Fix port used to determine who the host is

### DIFF
--- a/src/main/java/rxbroadcast/UdpBroadcast.java
+++ b/src/main/java/rxbroadcast/UdpBroadcast.java
@@ -38,7 +38,7 @@ public final class UdpBroadcast<T> implements Broadcast {
         final Scheduler singleThreadScheduler = Schedulers.from(
             Executors.newSingleThreadScheduledExecutor(new DaemonThreadFactory()));
         final Single<Sender> host = Single.fromCallable(new WhoAmI(
-            destination.getPort(), destination.getAddress() instanceof Inet6Address));
+            socket.getLocalPort(), destination.getAddress() instanceof Inet6Address));
         this.broadcastOrder = host.subscribeOn(Schedulers.io()).map(createBroadcastOrder::apply).cache();
         this.broadcastOrder.subscribe();
         this.values = broadcastOrder.flatMapObservable((order1) ->

--- a/src/main/java/rxbroadcast/WhoAmI.java
+++ b/src/main/java/rxbroadcast/WhoAmI.java
@@ -17,10 +17,10 @@ final class WhoAmI implements Callable<Sender> {
 
     private final boolean ipv6;
 
-    private final int destinationPort;
+    private final int port;
 
-    WhoAmI(final int destinationPort, final boolean ipv6) {
-        this.destinationPort = destinationPort;
+    WhoAmI(final int port, final boolean ipv6) {
+        this.port = port;
         this.ipv6 = ipv6;
     }
 
@@ -30,7 +30,7 @@ final class WhoAmI implements Callable<Sender> {
         // Listen on all interfaces, random port
         final DatagramSocket ws = new DatagramSocket();
         final DatagramPacket recvPacket = sendRecv(ws);
-        return new Sender(recvPacket.getAddress(), destinationPort);
+        return new Sender(recvPacket.getAddress(), port);
     }
 
     @SuppressWarnings("checkstyle:AvoidInlineConditionals")

--- a/test/two_way.py
+++ b/test/two_way.py
@@ -47,6 +47,7 @@ parser = argparse.ArgumentParser(description='RxBroadcast table tennis test scri
 parser.add_argument('--help', action='help', help='show this help message and exit')
 parser.add_argument('--image', default=DEFAULT_IMAGE_NAME, help='the Docker image name to use for the containers')
 parser.add_argument('--ipv6', action='store_true', help='use IPv6 for the network addresses')
+parser.add_argument('--no-remove', action='store_true', help="don't remove successful containers")
 parser.add_argument('--num-junit-containers', default=DEFAULT_NUM_TEST_CONTAINERS, type=int, help='the number of JUnit containers to create')
 parser.add_argument('class_name', help='the fully qualified name of the test class to run')
 parser.add_argument('network_command', nargs='?', default=':', help='a network command to apply to the JUnit container network interface')
@@ -105,7 +106,8 @@ try:
             errors += 1
         else:
             print(colored('{} exited successfully'.format(container.short_id), 'green'))
-            container.remove()
+            if not args.no_remove:
+                container.remove()
 except KeyboardInterrupt:
     stop_all_containers()
 


### PR DESCRIPTION
This PR fixes a bug with the port used to construct the sender in `WhoAmI`. The port being passed in was the destination port and not the local host port.

Extras 🍰:

- Add `--no-remove` to the two way test script (useful for debugging)
- Rename the port argument to `WhoAmI` as it's not the destination