### PR TITLE
Show Protocol Buffer files as languages on GH

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 * text=auto
 
+# Protocol Buffers are worth reporting as code
+*.proto linguist-detectable=true
+
 # Reviewing the lockfile contents is an important step in verifying that
 # we're using the dependencies we expect to be using
 Pipfile.lock linguist-generated=false


### PR DESCRIPTION
This PR updates the gitattrs file to show Protocol Buffers files in the GitHub language reporting.