### PR TITLE
Re-enable pitest on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,3 +64,5 @@ jobs:
         run: gradle errorProne
       - name: Run PMD
         run: gradle pmd{Main,Test}
+      - name: Run PIT tests
+        run: gradle pitest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,5 +64,16 @@ jobs:
         run: gradle errorProne
       - name: Run PMD
         run: gradle pmd{Main,Test}
+  mutation_tests:
+    name: Mutation tests
+    needs: [tests]
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup Java 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: '8'
       - name: Run PIT tests
         run: gradle pitest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     jacoco
     checkstyle
     pmd
-    id("info.solidsoft.pitest") version "1.2.4"
+    id("info.solidsoft.pitest") version "1.5.1"
     id("com.jfrog.bintray") version "1.6"
     id("net.ltgt.errorprone-base") version "0.0.13"
 }
@@ -96,13 +96,13 @@ task<Jar>("testJar") {
 }
 
 configure<PitestPluginExtension> {
-    excludedMethods = setOf("toString", "newThread", "hashCode")
-    detectInlinedCode = true
-    timestampedReports = false
-    mutationThreshold = 99
-    mutators = setOf("DEFAULTS", "REMOVE_CONDITIONALS")
-    testSourceSets = setOf(sourceSets["pitest"])
-    verbose = (System.getenv("CI") ?: "false").toBoolean()
+    excludedMethods.set(setOf("toString", "newThread", "hashCode"))
+    detectInlinedCode.set(true)
+    timestampedReports.set(false)
+    mutationThreshold.set(80)
+    mutators.set(setOf("ALL"))
+    testSourceSets.set(setOf(sourceSets["pitest"]))
+    verbose.set((System.getenv("CI") ?: "false").toBoolean())
 }
 
 task<Jar>("sourcesJar") {


### PR DESCRIPTION
Closes #212

This PR re-enables PIT on CI. I've lowered the coverage here since it's dropped on the newest version of PIT. (Yay, better analysis. 🎉)