### PR TITLE
Ignore Infer output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 .vagrant
 
 build
+/infer-out
 
 *.iml


### PR DESCRIPTION
This PR adds Infer's output directory, `infer-out`, to the `.gitignore` pattern list.